### PR TITLE
Add ISP GCC support

### DIFF
--- a/SampleCode/ISP/ISP_CAN/GCC/Makefile
+++ b/SampleCode/ISP/ISP_CAN/GCC/Makefile
@@ -1,0 +1,44 @@
+include ./makefile.conf
+NAME=ISP_CAN
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../../../../Library/StdDriver/src/can.c \
+	../../../../Library/StdDriver/src/clk.c \
+	../../../../Library/StdDriver/src/fmc.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_CAN/GCC/Makefile
+++ b/SampleCode/ISP/ISP_CAN/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_CAN/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_CAN/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+#STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_DFU/GCC/Makefile
+++ b/SampleCode/ISP/ISP_DFU/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_DFU/GCC/Makefile
+++ b/SampleCode/ISP/ISP_DFU/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_DFU
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_DFU/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_DFU/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+#STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_DFU/startup_M480_user_GCC.S
+++ b/SampleCode/ISP/ISP_DFU/startup_M480_user_GCC.S
@@ -1,0 +1,367 @@
+/****************************************************************************//**
+ * @file     startup_M480.S
+ * @version  V1.00
+ * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+
+
+	.syntax	unified
+	.arch	armv7-m
+
+	.section .stack
+	.align	3
+#ifdef __STACK_SIZE
+	.equ	Stack_Size, __STACK_SIZE
+#else
+	.equ	Stack_Size, 0x00000800
+#endif
+	.globl	__StackTop
+	.globl	__StackLimit
+__StackLimit:
+	.space	Stack_Size
+	.size	__StackLimit, . - __StackLimit
+__StackTop:
+	.size	__StackTop, . - __StackTop
+
+	.section .heap
+	.align	3
+#ifdef __HEAP_SIZE
+	.equ	Heap_Size, __HEAP_SIZE
+#else
+	.equ	Heap_Size, 0x00000100
+#endif
+	.globl	__HeapBase
+	.globl	__HeapLimit
+__HeapBase:
+	.if	Heap_Size
+	.space	Heap_Size
+	.endif
+	.size	__HeapBase, . - __HeapBase
+__HeapLimit:
+	.size	__HeapLimit, . - __HeapLimit
+
+	.section .vectors
+	.align	2
+	.globl	__Vectors
+__Vectors:
+	.long	__StackTop            /* Top of Stack */
+	.long	Reset_Handler         /* Reset Handler */
+	.long	NMI_Handler           /* NMI Handler */
+	.long	HardFault_Handler     /* Hard Fault Handler */
+	.long	MemManage_Handler     /* MPU Fault Handler */
+	.long	BusFault_Handler      /* Bus Fault Handler */
+	.long	UsageFault_Handler    /* Usage Fault Handler */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	SVC_Handler           /* SVCall Handler */
+	.long	DebugMon_Handler      /* Debug Monitor Handler */
+	.long	0                     /* Reserved */
+	.long	PendSV_Handler        /* PendSV Handler */
+	.long	SysTick_Handler       /* SysTick Handler */
+
+	/* External interrupts */
+
+
+	.size	__Vectors, . - __Vectors
+
+	.text
+	.thumb
+	.thumb_func
+	.align	2
+	.globl	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+/*  Firstly it copies data from read only memory to RAM. There are two schemes
+ *  to copy. One can copy more than one sections. Another can only copy
+ *  one section.  The former scheme needs more instructions and read-only
+ *  data to implement than the latter.
+ *  Macro __STARTUP_COPY_MULTIPLE is used to choose between two schemes.  */
+
+#ifdef __STARTUP_COPY_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of triplets, each of which specify:
+ *    offset 0: LMA of start of a section to copy from
+ *    offset 4: VMA of start of a section to copy to
+ *    offset 8: size of the section to copy. Must be multiply of 4
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r4, =__copy_table_start__
+	ldr	r5, =__copy_table_end__
+
+.L_loop0:
+	cmp	r4, r5
+	bge	.L_loop0_done
+	ldr	r1, [r4]
+	ldr	r2, [r4, #4]
+	ldr	r3, [r4, #8]
+
+.L_loop0_0:
+	subs	r3, #4
+	ittt	ge
+	ldrge	r0, [r1, r3]
+	strge	r0, [r2, r3]
+	bge	.L_loop0_0
+
+	adds	r4, #12
+	b	.L_loop0
+
+.L_loop0_done:
+#else
+/*  Single section scheme.
+ *
+ *  The ranges of copy from/to are specified by following symbols
+ *    __etext: LMA of start of the section to copy from. Usually end of text
+ *    __data_start__: VMA of start of the section to copy to
+ *    __data_end__: VMA of end of the section to copy to
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__etext
+	ldr	r2, =__data_start__
+	ldr	r3, =__data_end__
+
+.L_loop1:
+	cmp	r2, r3
+	ittt	lt
+	ldrlt	r0, [r1], #4
+	strlt	r0, [r2], #4
+	blt	.L_loop1
+#endif /*__STARTUP_COPY_MULTIPLE */
+
+/*  This part of work usually is done in C library startup code. Otherwise,
+ *  define this macro to enable it in this startup.
+ *
+ *  There are two schemes too. One can clear multiple BSS sections. Another
+ *  can only clear one section. The former is more size expensive than the
+ *  latter.
+ *
+ *  Define macro __STARTUP_CLEAR_BSS_MULTIPLE to choose the former.
+ *  Otherwise efine macro __STARTUP_CLEAR_BSS to choose the later.
+ */
+#ifdef __STARTUP_CLEAR_BSS_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of tuples specifying:
+ *    offset 0: Start of a BSS section
+ *    offset 4: Size of this BSS section. Must be multiply of 4
+ */
+	ldr	r3, =__zero_table_start__
+	ldr	r4, =__zero_table_end__
+
+.L_loop2:
+	cmp	r3, r4
+	bge	.L_loop2_done
+	ldr	r1, [r3]
+	ldr	r2, [r3, #4]
+	movs	r0, 0
+
+.L_loop2_0:
+	subs	r2, #4
+	itt	ge
+	strge	r0, [r1, r2]
+	bge	.L_loop2_0
+
+	adds	r3, #8
+	b	.L_loop2
+.L_loop2_done:
+#elif defined (__STARTUP_CLEAR_BSS)
+/*  Single BSS section scheme.
+ *
+ *  The BSS section is specified by following symbols
+ *    __bss_start__: start of the BSS section.
+ *    __bss_end__: end of the BSS section.
+ *
+ *  Both addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__bss_start__
+	ldr	r2, =__bss_end__
+
+	movs	r0, 0
+.L_loop3:
+	cmp	r1, r2
+	itt	lt
+	strlt	r0, [r1], #4
+	blt	.L_loop3
+#endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
+
+/*  Unlock Register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0x59
+	str	r1, [r0]
+	ldr	r1, =0x16
+	str	r1, [r0]
+	ldr	r1, =0x88
+	str	r1, [r0]
+
+#ifndef ENABLE_SPIM_CACHE
+	ldr	r0, =0x40000200            /* R0 = Clock Controller Register Base Address */
+	ldr	r1, [r0,#0x4]              /* R1 = 0x40000204  (AHBCLK) */
+	orr	r1, r1, #0x4000
+	str	r1, [r0,#0x4]              /* CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk; */
+
+	ldr	r0, =0x40007000            /* R0 = SPIM Register Base Address */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1,#2                  /* R1 |= SPIM_CTL1_CACHEOFF_Msk */
+	str	r1, [r0,#4]                /* _SPIM_DISABLE_CACHE() */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1, #4                 /* R1 |= SPIM_CTL1_CCMEN_Msk */
+	str	r1, [r0,#4]                /* _SPIM_ENABLE_CCM() */
+#endif
+
+#ifndef __NO_SYSTEM_INIT
+	bl	SystemInit
+#endif
+
+/* Init POR */
+#if 0
+	ldr	r0, =0x40000024
+	ldr	r1, =0x00005AA5
+	str	r1, [r0]
+#endif
+
+/* Lock register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0
+	str	r1, [r0]
+
+#ifndef __START
+#define __START _start
+#endif
+	bl	__START
+
+	.pool
+	.size	Reset_Handler, . - Reset_Handler
+
+	.align	1
+	.thumb_func
+	.weak	Default_Handler
+	.type	Default_Handler, %function
+Default_Handler:
+	b	.
+	.size	Default_Handler, . - Default_Handler
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+	.macro	def_irq_handler	handler_name
+	.weak	\handler_name
+	.set	\handler_name, Default_Handler
+	.endm
+
+	def_irq_handler	NMI_Handler
+	def_irq_handler	HardFault_Handler
+	def_irq_handler	MemManage_Handler
+	def_irq_handler	BusFault_Handler
+	def_irq_handler	UsageFault_Handler
+	def_irq_handler	SVC_Handler
+	def_irq_handler	DebugMon_Handler
+	def_irq_handler	PendSV_Handler
+	def_irq_handler	SysTick_Handler
+
+	def_irq_handler	BOD_IRQHandler
+	def_irq_handler	IRC_IRQHandler
+	def_irq_handler	PWRWU_IRQHandler
+	def_irq_handler	RAMPE_IRQHandler
+	def_irq_handler	CKFAIL_IRQHandler
+	def_irq_handler	RTC_IRQHandler
+	def_irq_handler	TAMPER_IRQHandler
+	def_irq_handler	WDT_IRQHandler
+	def_irq_handler	WWDT_IRQHandler
+	def_irq_handler	EINT0_IRQHandler
+	def_irq_handler	EINT1_IRQHandler
+	def_irq_handler	EINT2_IRQHandler
+	def_irq_handler	EINT3_IRQHandler
+	def_irq_handler	EINT4_IRQHandler
+	def_irq_handler	EINT5_IRQHandler
+	def_irq_handler	GPA_IRQHandler
+	def_irq_handler	GPB_IRQHandler
+	def_irq_handler	GPC_IRQHandler
+	def_irq_handler	GPD_IRQHandler
+	def_irq_handler	GPE_IRQHandler
+	def_irq_handler	GPF_IRQHandler
+	def_irq_handler	QSPI0_IRQHandler
+	def_irq_handler	SPI0_IRQHandler
+	def_irq_handler	BRAKE0_IRQHandler
+	def_irq_handler	EPWM0P0_IRQHandler
+	def_irq_handler	EPWM0P1_IRQHandler
+	def_irq_handler	EPWM0P2_IRQHandler
+	def_irq_handler	BRAKE1_IRQHandler
+	def_irq_handler	EPWM1P0_IRQHandler
+	def_irq_handler	EPWM1P1_IRQHandler
+	def_irq_handler	EPWM1P2_IRQHandler
+	def_irq_handler	TMR0_IRQHandler
+	def_irq_handler	TMR1_IRQHandler
+	def_irq_handler	TMR2_IRQHandler
+	def_irq_handler	TMR3_IRQHandler
+	def_irq_handler	UART0_IRQHandler
+	def_irq_handler	UART1_IRQHandler
+	def_irq_handler	I2C0_IRQHandler
+	def_irq_handler	I2C1_IRQHandler
+	def_irq_handler	PDMA_IRQHandler
+	def_irq_handler	DAC_IRQHandler
+	def_irq_handler	EADC00_IRQHandler
+	def_irq_handler	EADC01_IRQHandler
+	def_irq_handler	ACMP01_IRQHandler
+	def_irq_handler	EADC02_IRQHandler
+	def_irq_handler	EADC03_IRQHandler
+	def_irq_handler	UART2_IRQHandler
+	def_irq_handler	UART3_IRQHandler
+	def_irq_handler	QSPI1_IRQHandler
+	def_irq_handler	SPI1_IRQHandler
+	def_irq_handler	SPI2_IRQHandler
+	def_irq_handler	USBD_IRQHandler
+	def_irq_handler	OHCI_IRQHandler
+	def_irq_handler	USBOTG_IRQHandler
+	def_irq_handler	CAN0_IRQHandler
+	def_irq_handler	CAN1_IRQHandler
+	def_irq_handler	SC0_IRQHandler
+	def_irq_handler	SC1_IRQHandler
+	def_irq_handler	SC2_IRQHandler
+	def_irq_handler	SPI3_IRQHandler
+	def_irq_handler	SDH0_IRQHandler
+	def_irq_handler	USBD20_IRQHandler
+	def_irq_handler	EMAC_TX_IRQHandler
+	def_irq_handler	EMAC_RX_IRQHandler
+	def_irq_handler	I2S0_IRQHandler
+	def_irq_handler	OPA0_IRQHandler
+	def_irq_handler	CRYPTO_IRQHandler
+	def_irq_handler	GPG_IRQHandler
+	def_irq_handler	EINT6_IRQHandler
+	def_irq_handler	UART4_IRQHandler
+	def_irq_handler	UART5_IRQHandler
+	def_irq_handler	USCI0_IRQHandler
+	def_irq_handler	USCI1_IRQHandler
+	def_irq_handler	BPWM0_IRQHandler
+	def_irq_handler	BPWM1_IRQHandler
+	def_irq_handler	SPIM_IRQHandler
+	def_irq_handler CCAP_IRQHandler
+	def_irq_handler	I2C2_IRQHandler
+	def_irq_handler	QEI0_IRQHandler
+	def_irq_handler	QEI1_IRQHandler
+	def_irq_handler	ECAP0_IRQHandler
+	def_irq_handler	ECAP1_IRQHandler
+	def_irq_handler	GPH_IRQHandler
+	def_irq_handler	EINT7_IRQHandler
+	def_irq_handler	SDH1_IRQHandler
+	def_irq_handler	EHCI_IRQHandler
+	def_irq_handler	USBOTG20_IRQHandler
+	def_irq_handler	TRNG_IRQHandler
+	def_irq_handler	UART6_IRQHandler
+	def_irq_handler	UART7_IRQHandler
+	def_irq_handler	EADC10_IRQHandler
+	def_irq_handler	EADC11_IRQHandler
+	def_irq_handler	EADC12_IRQHandler
+	def_irq_handler	EADC13_IRQHandler
+	def_irq_handler	CAN2_IRQHandler
+
+	.end

--- a/SampleCode/ISP/ISP_DFU/startup_M480_user_IAR.s
+++ b/SampleCode/ISP/ISP_DFU/startup_M480_user_IAR.s
@@ -1,0 +1,344 @@
+;/******************************************************************************
+; * @file     startup_M480.s
+; * @version  V1.00
+; * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+; *
+; * SPDX-License-Identifier: Apache-2.0
+; * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+;*****************************************************************************/
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  HardFault_Handler
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+        PUBLIC  __vector_table_0x1c
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler
+
+        DCD     NMI_Handler
+        DCD     HardFault_Handler
+        DCD     MemManage_Handler
+        DCD     BusFault_Handler
+        DCD     UsageFault_Handler
+__vector_table_0x1c
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     SVC_Handler
+        DCD     DebugMon_Handler
+        DCD     0
+        DCD     PendSV_Handler
+        DCD     SysTick_Handler
+
+        ; External Interrupts
+
+__Vectors_End
+
+__Vectors       EQU   __vector_table
+__Vectors_Size  EQU   __Vectors_End - __Vectors
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:REORDER:NOROOT(2)
+Reset_Handler
+        ; Unlock Register
+        LDR     R0, =0x40000100
+        LDR     R1, =0x59
+        STR     R1, [R0]
+        LDR     R1, =0x16
+        STR     R1, [R0]
+        LDR     R1, =0x88
+        STR     R1, [R0]
+
+	#ifndef ENABLE_SPIM_CACHE
+        LDR     R0, =0x40000200            ; R0 = Clock Controller Register Base Address
+        LDR     R1, [R0,#0x4]              ; R1 = 0x40000204  (AHBCLK)
+        ORR     R1, R1, #0x4000              
+        STR     R1, [R0,#0x4]              ; CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk;
+                
+        LDR     R0, =0x40007000            ; R0 = SPIM Register Base Address
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1,#2                  ; R1 |= SPIM_CTL1_CACHEOFF_Msk
+        STR     R1, [R0,#4]                ; _SPIM_DISABLE_CACHE()
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1, #4                 ; R1 |= SPIM_CTL1_CCMEN_Msk
+        STR     R1, [R0,#4]                ; _SPIM_ENABLE_CCM()
+	#endif
+
+        LDR     R0, =SystemInit
+        BLX     R0
+
+        ; Init POR
+        ; LDR     R2, =0x40000024
+        ; LDR     R1, =0x00005AA5
+        ; STR     R1, [R2]
+
+        ; Lock register
+        LDR     R0, =0x40000100
+        MOVS    R1, #0
+        STR     R1, [R0]
+
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+NMI_Handler
+        B NMI_Handler
+
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+UsageFault_Handler
+        B UsageFault_Handler
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SVC_Handler
+        B SVC_Handler
+
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+DebugMon_Handler
+        B DebugMon_Handler
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+PendSV_Handler
+        B PendSV_Handler
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SysTick_Handler
+        B SysTick_Handler
+
+        PUBWEAK  BOD_IRQHandler
+        PUBWEAK  IRC_IRQHandler
+        PUBWEAK  PWRWU_IRQHandler
+        PUBWEAK  RAMPE_IRQHandler
+        PUBWEAK  CKFAIL_IRQHandler
+        PUBWEAK  RTC_IRQHandler
+        PUBWEAK  TAMPER_IRQHandler
+        PUBWEAK  WDT_IRQHandler
+        PUBWEAK  WWDT_IRQHandler
+        PUBWEAK  EINT0_IRQHandler
+        PUBWEAK  EINT1_IRQHandler
+        PUBWEAK  EINT2_IRQHandler
+        PUBWEAK  EINT3_IRQHandler
+        PUBWEAK  EINT4_IRQHandler
+        PUBWEAK  EINT5_IRQHandler
+        PUBWEAK  GPA_IRQHandler
+        PUBWEAK  GPB_IRQHandler
+        PUBWEAK  GPC_IRQHandler
+        PUBWEAK  GPD_IRQHandler
+        PUBWEAK  GPE_IRQHandler
+        PUBWEAK  GPF_IRQHandler
+        PUBWEAK  QSPI0_IRQHandler
+        PUBWEAK  SPI0_IRQHandler
+        PUBWEAK  BRAKE0_IRQHandler
+        PUBWEAK  PWM0P0_IRQHandler
+        PUBWEAK  PWM0P1_IRQHandler
+        PUBWEAK  PWM0P2_IRQHandler
+        PUBWEAK  BRAKE1_IRQHandler
+        PUBWEAK  PWM1P0_IRQHandler
+        PUBWEAK  PWM1P1_IRQHandler
+        PUBWEAK  PWM1P2_IRQHandler
+        PUBWEAK  TMR0_IRQHandler
+        PUBWEAK  TMR1_IRQHandler
+        PUBWEAK  TMR2_IRQHandler
+        PUBWEAK  TMR3_IRQHandler
+        PUBWEAK  UART0_IRQHandler
+        PUBWEAK  UART1_IRQHandler
+        PUBWEAK  I2C0_IRQHandler
+        PUBWEAK  I2C1_IRQHandler
+        PUBWEAK  PDMA_IRQHandler
+        PUBWEAK  DAC_IRQHandler
+        PUBWEAK  EADC00_IRQHandler
+        PUBWEAK  EADC01_IRQHandler
+        PUBWEAK  ACMP01_IRQHandler
+        PUBWEAK  EADC02_IRQHandler
+        PUBWEAK  EADC03_IRQHandler
+        PUBWEAK  UART2_IRQHandler
+        PUBWEAK  UART3_IRQHandler
+        PUBWEAK  QSPI1_IRQHandler
+        PUBWEAK  SPI1_IRQHandler
+        PUBWEAK  SPI2_IRQHandler
+        PUBWEAK  USBD_IRQHandler
+        PUBWEAK  OHCI_IRQHandler
+        PUBWEAK  USBOTG_IRQHandler
+        PUBWEAK  CAN0_IRQHandler
+        PUBWEAK  CAN1_IRQHandler
+        PUBWEAK  SC0_IRQHandler
+        PUBWEAK  SC1_IRQHandler
+        PUBWEAK  SC2_IRQHandler
+        PUBWEAK  SPI3_IRQHandler
+        PUBWEAK  SDH0_IRQHandler
+        PUBWEAK  USBD20_IRQHandler
+        PUBWEAK  EMAC_TX_IRQHandler
+        PUBWEAK  EMAC_RX_IRQHandler
+        PUBWEAK  I2S0_IRQHandler
+        PUBWEAK  OPA0_IRQHandler
+        PUBWEAK  CRYPTO_IRQHandler
+        PUBWEAK  GPG_IRQHandler
+        PUBWEAK  EINT6_IRQHandler
+        PUBWEAK  UART4_IRQHandler
+        PUBWEAK  UART5_IRQHandler
+        PUBWEAK  USCI0_IRQHandler
+        PUBWEAK  USCI1_IRQHandler
+        PUBWEAK  BPWM0_IRQHandler
+        PUBWEAK  BPWM1_IRQHandler
+        PUBWEAK  SPIM_IRQHandler
+        PUBWEAK  CCAP_IRQHandler
+        PUBWEAK  I2C2_IRQHandler
+        PUBWEAK  QEI0_IRQHandler
+        PUBWEAK  QEI1_IRQHandler
+        PUBWEAK  ECAP0_IRQHandler
+        PUBWEAK  ECAP1_IRQHandler
+        PUBWEAK  GPH_IRQHandler
+        PUBWEAK  EINT7_IRQHandler
+        PUBWEAK  SDH1_IRQHandler
+        PUBWEAK  EHCI_IRQHandler
+        PUBWEAK  USBOTG20_IRQHandler
+        PUBWEAK  TRNG_IRQHandler
+        PUBWEAK  UART6_IRQHandler
+        PUBWEAK  UART7_IRQHandler
+        PUBWEAK  EADC10_IRQHandler
+        PUBWEAK  EADC11_IRQHandler
+        PUBWEAK  EADC12_IRQHandler
+        PUBWEAK  EADC13_IRQHandler
+        PUBWEAK  CAN2_IRQHandler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+
+BOD_IRQHandler
+IRC_IRQHandler
+PWRWU_IRQHandler
+RAMPE_IRQHandler
+CKFAIL_IRQHandler
+RTC_IRQHandler
+TAMPER_IRQHandler
+WDT_IRQHandler
+WWDT_IRQHandler
+EINT0_IRQHandler
+EINT1_IRQHandler
+EINT2_IRQHandler
+EINT3_IRQHandler
+EINT4_IRQHandler
+EINT5_IRQHandler
+GPA_IRQHandler
+GPB_IRQHandler
+GPC_IRQHandler
+GPD_IRQHandler
+GPE_IRQHandler
+GPF_IRQHandler
+QSPI0_IRQHandler
+SPI0_IRQHandler
+BRAKE0_IRQHandler
+PWM0P0_IRQHandler
+PWM0P1_IRQHandler
+PWM0P2_IRQHandler
+BRAKE1_IRQHandler
+PWM1P0_IRQHandler
+PWM1P1_IRQHandler
+PWM1P2_IRQHandler
+TMR0_IRQHandler
+TMR1_IRQHandler
+TMR2_IRQHandler
+TMR3_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+PDMA_IRQHandler
+DAC_IRQHandler
+EADC00_IRQHandler
+EADC01_IRQHandler
+ACMP01_IRQHandler
+EADC02_IRQHandler
+EADC03_IRQHandler
+UART2_IRQHandler
+UART3_IRQHandler
+QSPI1_IRQHandler
+SPI1_IRQHandler
+SPI2_IRQHandler
+USBD_IRQHandler
+OHCI_IRQHandler
+USBOTG_IRQHandler
+CAN0_IRQHandler
+CAN1_IRQHandler
+SC0_IRQHandler
+SC1_IRQHandler
+SC2_IRQHandler
+SPI3_IRQHandler
+SDH0_IRQHandler
+USBD20_IRQHandler
+EMAC_TX_IRQHandler
+EMAC_RX_IRQHandler
+I2S0_IRQHandler
+OPA0_IRQHandler
+CRYPTO_IRQHandler
+GPG_IRQHandler
+EINT6_IRQHandler
+UART4_IRQHandler
+UART5_IRQHandler
+USCI0_IRQHandler
+USCI1_IRQHandler
+BPWM0_IRQHandler
+BPWM1_IRQHandler
+SPIM_IRQHandler
+CCAP_IRQHandler
+I2C2_IRQHandler
+QEI0_IRQHandler
+QEI1_IRQHandler
+ECAP0_IRQHandler
+ECAP1_IRQHandler
+GPH_IRQHandler
+EINT7_IRQHandler
+SDH1_IRQHandler
+EHCI_IRQHandler
+USBOTG20_IRQHandler
+TRNG_IRQHandler
+UART6_IRQHandler
+UART7_IRQHandler
+EADC10_IRQHandler
+EADC11_IRQHandler
+EADC12_IRQHandler
+EADC13_IRQHandler
+CAN2_IRQHandler
+Default_Handler
+        B Default_Handler
+
+
+
+
+        END
+;/*** (C) COPYRIGHT 2016 Nuvoton Technology Corp. ***/

--- a/SampleCode/ISP/ISP_DFU_20/GCC/Makefile
+++ b/SampleCode/ISP/ISP_DFU_20/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_DFU_20
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_DFU_20/GCC/Makefile
+++ b/SampleCode/ISP/ISP_DFU_20/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_DFU_20/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_DFU_20/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+#STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_DFU_20/fmc_user.c
+++ b/SampleCode/ISP/ISP_DFU_20/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_DFU_20/fmc_user.h
+++ b/SampleCode/ISP/ISP_DFU_20/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_DFU_20/isp_user.c
+++ b/SampleCode/ISP/ISP_DFU_20/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_DFU_20/isp_user.h
+++ b/SampleCode/ISP/ISP_DFU_20/isp_user.h
@@ -42,7 +42,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_DFU_20/startup_M480_user_GCC.S
+++ b/SampleCode/ISP/ISP_DFU_20/startup_M480_user_GCC.S
@@ -1,0 +1,367 @@
+/****************************************************************************//**
+ * @file     startup_M480.S
+ * @version  V1.00
+ * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+
+
+	.syntax	unified
+	.arch	armv7-m
+
+	.section .stack
+	.align	3
+#ifdef __STACK_SIZE
+	.equ	Stack_Size, __STACK_SIZE
+#else
+	.equ	Stack_Size, 0x00000800
+#endif
+	.globl	__StackTop
+	.globl	__StackLimit
+__StackLimit:
+	.space	Stack_Size
+	.size	__StackLimit, . - __StackLimit
+__StackTop:
+	.size	__StackTop, . - __StackTop
+
+	.section .heap
+	.align	3
+#ifdef __HEAP_SIZE
+	.equ	Heap_Size, __HEAP_SIZE
+#else
+	.equ	Heap_Size, 0x00000100
+#endif
+	.globl	__HeapBase
+	.globl	__HeapLimit
+__HeapBase:
+	.if	Heap_Size
+	.space	Heap_Size
+	.endif
+	.size	__HeapBase, . - __HeapBase
+__HeapLimit:
+	.size	__HeapLimit, . - __HeapLimit
+
+	.section .vectors
+	.align	2
+	.globl	__Vectors
+__Vectors:
+	.long	__StackTop            /* Top of Stack */
+	.long	Reset_Handler         /* Reset Handler */
+	.long	NMI_Handler           /* NMI Handler */
+	.long	HardFault_Handler     /* Hard Fault Handler */
+	.long	MemManage_Handler     /* MPU Fault Handler */
+	.long	BusFault_Handler      /* Bus Fault Handler */
+	.long	UsageFault_Handler    /* Usage Fault Handler */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	SVC_Handler           /* SVCall Handler */
+	.long	DebugMon_Handler      /* Debug Monitor Handler */
+	.long	0                     /* Reserved */
+	.long	PendSV_Handler        /* PendSV Handler */
+	.long	SysTick_Handler       /* SysTick Handler */
+
+	/* External interrupts */
+
+
+	.size	__Vectors, . - __Vectors
+
+	.text
+	.thumb
+	.thumb_func
+	.align	2
+	.globl	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+/*  Firstly it copies data from read only memory to RAM. There are two schemes
+ *  to copy. One can copy more than one sections. Another can only copy
+ *  one section.  The former scheme needs more instructions and read-only
+ *  data to implement than the latter.
+ *  Macro __STARTUP_COPY_MULTIPLE is used to choose between two schemes.  */
+
+#ifdef __STARTUP_COPY_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of triplets, each of which specify:
+ *    offset 0: LMA of start of a section to copy from
+ *    offset 4: VMA of start of a section to copy to
+ *    offset 8: size of the section to copy. Must be multiply of 4
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r4, =__copy_table_start__
+	ldr	r5, =__copy_table_end__
+
+.L_loop0:
+	cmp	r4, r5
+	bge	.L_loop0_done
+	ldr	r1, [r4]
+	ldr	r2, [r4, #4]
+	ldr	r3, [r4, #8]
+
+.L_loop0_0:
+	subs	r3, #4
+	ittt	ge
+	ldrge	r0, [r1, r3]
+	strge	r0, [r2, r3]
+	bge	.L_loop0_0
+
+	adds	r4, #12
+	b	.L_loop0
+
+.L_loop0_done:
+#else
+/*  Single section scheme.
+ *
+ *  The ranges of copy from/to are specified by following symbols
+ *    __etext: LMA of start of the section to copy from. Usually end of text
+ *    __data_start__: VMA of start of the section to copy to
+ *    __data_end__: VMA of end of the section to copy to
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__etext
+	ldr	r2, =__data_start__
+	ldr	r3, =__data_end__
+
+.L_loop1:
+	cmp	r2, r3
+	ittt	lt
+	ldrlt	r0, [r1], #4
+	strlt	r0, [r2], #4
+	blt	.L_loop1
+#endif /*__STARTUP_COPY_MULTIPLE */
+
+/*  This part of work usually is done in C library startup code. Otherwise,
+ *  define this macro to enable it in this startup.
+ *
+ *  There are two schemes too. One can clear multiple BSS sections. Another
+ *  can only clear one section. The former is more size expensive than the
+ *  latter.
+ *
+ *  Define macro __STARTUP_CLEAR_BSS_MULTIPLE to choose the former.
+ *  Otherwise efine macro __STARTUP_CLEAR_BSS to choose the later.
+ */
+#ifdef __STARTUP_CLEAR_BSS_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of tuples specifying:
+ *    offset 0: Start of a BSS section
+ *    offset 4: Size of this BSS section. Must be multiply of 4
+ */
+	ldr	r3, =__zero_table_start__
+	ldr	r4, =__zero_table_end__
+
+.L_loop2:
+	cmp	r3, r4
+	bge	.L_loop2_done
+	ldr	r1, [r3]
+	ldr	r2, [r3, #4]
+	movs	r0, 0
+
+.L_loop2_0:
+	subs	r2, #4
+	itt	ge
+	strge	r0, [r1, r2]
+	bge	.L_loop2_0
+
+	adds	r3, #8
+	b	.L_loop2
+.L_loop2_done:
+#elif defined (__STARTUP_CLEAR_BSS)
+/*  Single BSS section scheme.
+ *
+ *  The BSS section is specified by following symbols
+ *    __bss_start__: start of the BSS section.
+ *    __bss_end__: end of the BSS section.
+ *
+ *  Both addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__bss_start__
+	ldr	r2, =__bss_end__
+
+	movs	r0, 0
+.L_loop3:
+	cmp	r1, r2
+	itt	lt
+	strlt	r0, [r1], #4
+	blt	.L_loop3
+#endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
+
+/*  Unlock Register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0x59
+	str	r1, [r0]
+	ldr	r1, =0x16
+	str	r1, [r0]
+	ldr	r1, =0x88
+	str	r1, [r0]
+
+#ifndef ENABLE_SPIM_CACHE
+	ldr	r0, =0x40000200            /* R0 = Clock Controller Register Base Address */
+	ldr	r1, [r0,#0x4]              /* R1 = 0x40000204  (AHBCLK) */
+	orr	r1, r1, #0x4000
+	str	r1, [r0,#0x4]              /* CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk; */
+
+	ldr	r0, =0x40007000            /* R0 = SPIM Register Base Address */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1,#2                  /* R1 |= SPIM_CTL1_CACHEOFF_Msk */
+	str	r1, [r0,#4]                /* _SPIM_DISABLE_CACHE() */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1, #4                 /* R1 |= SPIM_CTL1_CCMEN_Msk */
+	str	r1, [r0,#4]                /* _SPIM_ENABLE_CCM() */
+#endif
+
+#ifndef __NO_SYSTEM_INIT
+	bl	SystemInit
+#endif
+
+/* Init POR */
+#if 0
+	ldr	r0, =0x40000024
+	ldr	r1, =0x00005AA5
+	str	r1, [r0]
+#endif
+
+/* Lock register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0
+	str	r1, [r0]
+
+#ifndef __START
+#define __START _start
+#endif
+	bl	__START
+
+	.pool
+	.size	Reset_Handler, . - Reset_Handler
+
+	.align	1
+	.thumb_func
+	.weak	Default_Handler
+	.type	Default_Handler, %function
+Default_Handler:
+	b	.
+	.size	Default_Handler, . - Default_Handler
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+	.macro	def_irq_handler	handler_name
+	.weak	\handler_name
+	.set	\handler_name, Default_Handler
+	.endm
+
+	def_irq_handler	NMI_Handler
+	def_irq_handler	HardFault_Handler
+	def_irq_handler	MemManage_Handler
+	def_irq_handler	BusFault_Handler
+	def_irq_handler	UsageFault_Handler
+	def_irq_handler	SVC_Handler
+	def_irq_handler	DebugMon_Handler
+	def_irq_handler	PendSV_Handler
+	def_irq_handler	SysTick_Handler
+
+	def_irq_handler	BOD_IRQHandler
+	def_irq_handler	IRC_IRQHandler
+	def_irq_handler	PWRWU_IRQHandler
+	def_irq_handler	RAMPE_IRQHandler
+	def_irq_handler	CKFAIL_IRQHandler
+	def_irq_handler	RTC_IRQHandler
+	def_irq_handler	TAMPER_IRQHandler
+	def_irq_handler	WDT_IRQHandler
+	def_irq_handler	WWDT_IRQHandler
+	def_irq_handler	EINT0_IRQHandler
+	def_irq_handler	EINT1_IRQHandler
+	def_irq_handler	EINT2_IRQHandler
+	def_irq_handler	EINT3_IRQHandler
+	def_irq_handler	EINT4_IRQHandler
+	def_irq_handler	EINT5_IRQHandler
+	def_irq_handler	GPA_IRQHandler
+	def_irq_handler	GPB_IRQHandler
+	def_irq_handler	GPC_IRQHandler
+	def_irq_handler	GPD_IRQHandler
+	def_irq_handler	GPE_IRQHandler
+	def_irq_handler	GPF_IRQHandler
+	def_irq_handler	QSPI0_IRQHandler
+	def_irq_handler	SPI0_IRQHandler
+	def_irq_handler	BRAKE0_IRQHandler
+	def_irq_handler	EPWM0P0_IRQHandler
+	def_irq_handler	EPWM0P1_IRQHandler
+	def_irq_handler	EPWM0P2_IRQHandler
+	def_irq_handler	BRAKE1_IRQHandler
+	def_irq_handler	EPWM1P0_IRQHandler
+	def_irq_handler	EPWM1P1_IRQHandler
+	def_irq_handler	EPWM1P2_IRQHandler
+	def_irq_handler	TMR0_IRQHandler
+	def_irq_handler	TMR1_IRQHandler
+	def_irq_handler	TMR2_IRQHandler
+	def_irq_handler	TMR3_IRQHandler
+	def_irq_handler	UART0_IRQHandler
+	def_irq_handler	UART1_IRQHandler
+	def_irq_handler	I2C0_IRQHandler
+	def_irq_handler	I2C1_IRQHandler
+	def_irq_handler	PDMA_IRQHandler
+	def_irq_handler	DAC_IRQHandler
+	def_irq_handler	EADC00_IRQHandler
+	def_irq_handler	EADC01_IRQHandler
+	def_irq_handler	ACMP01_IRQHandler
+	def_irq_handler	EADC02_IRQHandler
+	def_irq_handler	EADC03_IRQHandler
+	def_irq_handler	UART2_IRQHandler
+	def_irq_handler	UART3_IRQHandler
+	def_irq_handler	QSPI1_IRQHandler
+	def_irq_handler	SPI1_IRQHandler
+	def_irq_handler	SPI2_IRQHandler
+	def_irq_handler	USBD_IRQHandler
+	def_irq_handler	OHCI_IRQHandler
+	def_irq_handler	USBOTG_IRQHandler
+	def_irq_handler	CAN0_IRQHandler
+	def_irq_handler	CAN1_IRQHandler
+	def_irq_handler	SC0_IRQHandler
+	def_irq_handler	SC1_IRQHandler
+	def_irq_handler	SC2_IRQHandler
+	def_irq_handler	SPI3_IRQHandler
+	def_irq_handler	SDH0_IRQHandler
+	def_irq_handler	USBD20_IRQHandler
+	def_irq_handler	EMAC_TX_IRQHandler
+	def_irq_handler	EMAC_RX_IRQHandler
+	def_irq_handler	I2S0_IRQHandler
+	def_irq_handler	OPA0_IRQHandler
+	def_irq_handler	CRYPTO_IRQHandler
+	def_irq_handler	GPG_IRQHandler
+	def_irq_handler	EINT6_IRQHandler
+	def_irq_handler	UART4_IRQHandler
+	def_irq_handler	UART5_IRQHandler
+	def_irq_handler	USCI0_IRQHandler
+	def_irq_handler	USCI1_IRQHandler
+	def_irq_handler	BPWM0_IRQHandler
+	def_irq_handler	BPWM1_IRQHandler
+	def_irq_handler	SPIM_IRQHandler
+	def_irq_handler CCAP_IRQHandler
+	def_irq_handler	I2C2_IRQHandler
+	def_irq_handler	QEI0_IRQHandler
+	def_irq_handler	QEI1_IRQHandler
+	def_irq_handler	ECAP0_IRQHandler
+	def_irq_handler	ECAP1_IRQHandler
+	def_irq_handler	GPH_IRQHandler
+	def_irq_handler	EINT7_IRQHandler
+	def_irq_handler	SDH1_IRQHandler
+	def_irq_handler	EHCI_IRQHandler
+	def_irq_handler	USBOTG20_IRQHandler
+	def_irq_handler	TRNG_IRQHandler
+	def_irq_handler	UART6_IRQHandler
+	def_irq_handler	UART7_IRQHandler
+	def_irq_handler	EADC10_IRQHandler
+	def_irq_handler	EADC11_IRQHandler
+	def_irq_handler	EADC12_IRQHandler
+	def_irq_handler	EADC13_IRQHandler
+	def_irq_handler	CAN2_IRQHandler
+
+	.end

--- a/SampleCode/ISP/ISP_DFU_20/startup_M480_user_IAR.s
+++ b/SampleCode/ISP/ISP_DFU_20/startup_M480_user_IAR.s
@@ -1,0 +1,344 @@
+;/******************************************************************************
+; * @file     startup_M480.s
+; * @version  V1.00
+; * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+; *
+; * SPDX-License-Identifier: Apache-2.0
+; * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+;*****************************************************************************/
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  HardFault_Handler
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+        PUBLIC  __vector_table_0x1c
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler
+
+        DCD     NMI_Handler
+        DCD     HardFault_Handler
+        DCD     MemManage_Handler
+        DCD     BusFault_Handler
+        DCD     UsageFault_Handler
+__vector_table_0x1c
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     SVC_Handler
+        DCD     DebugMon_Handler
+        DCD     0
+        DCD     PendSV_Handler
+        DCD     SysTick_Handler
+
+        ; External Interrupts
+
+__Vectors_End
+
+__Vectors       EQU   __vector_table
+__Vectors_Size  EQU   __Vectors_End - __Vectors
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:REORDER:NOROOT(2)
+Reset_Handler
+        ; Unlock Register
+        LDR     R0, =0x40000100
+        LDR     R1, =0x59
+        STR     R1, [R0]
+        LDR     R1, =0x16
+        STR     R1, [R0]
+        LDR     R1, =0x88
+        STR     R1, [R0]
+
+	#ifndef ENABLE_SPIM_CACHE
+        LDR     R0, =0x40000200            ; R0 = Clock Controller Register Base Address
+        LDR     R1, [R0,#0x4]              ; R1 = 0x40000204  (AHBCLK)
+        ORR     R1, R1, #0x4000              
+        STR     R1, [R0,#0x4]              ; CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk;
+                
+        LDR     R0, =0x40007000            ; R0 = SPIM Register Base Address
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1,#2                  ; R1 |= SPIM_CTL1_CACHEOFF_Msk
+        STR     R1, [R0,#4]                ; _SPIM_DISABLE_CACHE()
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1, #4                 ; R1 |= SPIM_CTL1_CCMEN_Msk
+        STR     R1, [R0,#4]                ; _SPIM_ENABLE_CCM()
+	#endif
+
+        LDR     R0, =SystemInit
+        BLX     R0
+
+        ; Init POR
+        ; LDR     R2, =0x40000024
+        ; LDR     R1, =0x00005AA5
+        ; STR     R1, [R2]
+
+        ; Lock register
+        LDR     R0, =0x40000100
+        MOVS    R1, #0
+        STR     R1, [R0]
+
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+NMI_Handler
+        B NMI_Handler
+
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+UsageFault_Handler
+        B UsageFault_Handler
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SVC_Handler
+        B SVC_Handler
+
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+DebugMon_Handler
+        B DebugMon_Handler
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+PendSV_Handler
+        B PendSV_Handler
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SysTick_Handler
+        B SysTick_Handler
+
+        PUBWEAK  BOD_IRQHandler
+        PUBWEAK  IRC_IRQHandler
+        PUBWEAK  PWRWU_IRQHandler
+        PUBWEAK  RAMPE_IRQHandler
+        PUBWEAK  CKFAIL_IRQHandler
+        PUBWEAK  RTC_IRQHandler
+        PUBWEAK  TAMPER_IRQHandler
+        PUBWEAK  WDT_IRQHandler
+        PUBWEAK  WWDT_IRQHandler
+        PUBWEAK  EINT0_IRQHandler
+        PUBWEAK  EINT1_IRQHandler
+        PUBWEAK  EINT2_IRQHandler
+        PUBWEAK  EINT3_IRQHandler
+        PUBWEAK  EINT4_IRQHandler
+        PUBWEAK  EINT5_IRQHandler
+        PUBWEAK  GPA_IRQHandler
+        PUBWEAK  GPB_IRQHandler
+        PUBWEAK  GPC_IRQHandler
+        PUBWEAK  GPD_IRQHandler
+        PUBWEAK  GPE_IRQHandler
+        PUBWEAK  GPF_IRQHandler
+        PUBWEAK  QSPI0_IRQHandler
+        PUBWEAK  SPI0_IRQHandler
+        PUBWEAK  BRAKE0_IRQHandler
+        PUBWEAK  PWM0P0_IRQHandler
+        PUBWEAK  PWM0P1_IRQHandler
+        PUBWEAK  PWM0P2_IRQHandler
+        PUBWEAK  BRAKE1_IRQHandler
+        PUBWEAK  PWM1P0_IRQHandler
+        PUBWEAK  PWM1P1_IRQHandler
+        PUBWEAK  PWM1P2_IRQHandler
+        PUBWEAK  TMR0_IRQHandler
+        PUBWEAK  TMR1_IRQHandler
+        PUBWEAK  TMR2_IRQHandler
+        PUBWEAK  TMR3_IRQHandler
+        PUBWEAK  UART0_IRQHandler
+        PUBWEAK  UART1_IRQHandler
+        PUBWEAK  I2C0_IRQHandler
+        PUBWEAK  I2C1_IRQHandler
+        PUBWEAK  PDMA_IRQHandler
+        PUBWEAK  DAC_IRQHandler
+        PUBWEAK  EADC00_IRQHandler
+        PUBWEAK  EADC01_IRQHandler
+        PUBWEAK  ACMP01_IRQHandler
+        PUBWEAK  EADC02_IRQHandler
+        PUBWEAK  EADC03_IRQHandler
+        PUBWEAK  UART2_IRQHandler
+        PUBWEAK  UART3_IRQHandler
+        PUBWEAK  QSPI1_IRQHandler
+        PUBWEAK  SPI1_IRQHandler
+        PUBWEAK  SPI2_IRQHandler
+        PUBWEAK  USBD_IRQHandler
+        PUBWEAK  OHCI_IRQHandler
+        PUBWEAK  USBOTG_IRQHandler
+        PUBWEAK  CAN0_IRQHandler
+        PUBWEAK  CAN1_IRQHandler
+        PUBWEAK  SC0_IRQHandler
+        PUBWEAK  SC1_IRQHandler
+        PUBWEAK  SC2_IRQHandler
+        PUBWEAK  SPI3_IRQHandler
+        PUBWEAK  SDH0_IRQHandler
+        PUBWEAK  USBD20_IRQHandler
+        PUBWEAK  EMAC_TX_IRQHandler
+        PUBWEAK  EMAC_RX_IRQHandler
+        PUBWEAK  I2S0_IRQHandler
+        PUBWEAK  OPA0_IRQHandler
+        PUBWEAK  CRYPTO_IRQHandler
+        PUBWEAK  GPG_IRQHandler
+        PUBWEAK  EINT6_IRQHandler
+        PUBWEAK  UART4_IRQHandler
+        PUBWEAK  UART5_IRQHandler
+        PUBWEAK  USCI0_IRQHandler
+        PUBWEAK  USCI1_IRQHandler
+        PUBWEAK  BPWM0_IRQHandler
+        PUBWEAK  BPWM1_IRQHandler
+        PUBWEAK  SPIM_IRQHandler
+        PUBWEAK  CCAP_IRQHandler
+        PUBWEAK  I2C2_IRQHandler
+        PUBWEAK  QEI0_IRQHandler
+        PUBWEAK  QEI1_IRQHandler
+        PUBWEAK  ECAP0_IRQHandler
+        PUBWEAK  ECAP1_IRQHandler
+        PUBWEAK  GPH_IRQHandler
+        PUBWEAK  EINT7_IRQHandler
+        PUBWEAK  SDH1_IRQHandler
+        PUBWEAK  EHCI_IRQHandler
+        PUBWEAK  USBOTG20_IRQHandler
+        PUBWEAK  TRNG_IRQHandler
+        PUBWEAK  UART6_IRQHandler
+        PUBWEAK  UART7_IRQHandler
+        PUBWEAK  EADC10_IRQHandler
+        PUBWEAK  EADC11_IRQHandler
+        PUBWEAK  EADC12_IRQHandler
+        PUBWEAK  EADC13_IRQHandler
+        PUBWEAK  CAN2_IRQHandler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+
+BOD_IRQHandler
+IRC_IRQHandler
+PWRWU_IRQHandler
+RAMPE_IRQHandler
+CKFAIL_IRQHandler
+RTC_IRQHandler
+TAMPER_IRQHandler
+WDT_IRQHandler
+WWDT_IRQHandler
+EINT0_IRQHandler
+EINT1_IRQHandler
+EINT2_IRQHandler
+EINT3_IRQHandler
+EINT4_IRQHandler
+EINT5_IRQHandler
+GPA_IRQHandler
+GPB_IRQHandler
+GPC_IRQHandler
+GPD_IRQHandler
+GPE_IRQHandler
+GPF_IRQHandler
+QSPI0_IRQHandler
+SPI0_IRQHandler
+BRAKE0_IRQHandler
+PWM0P0_IRQHandler
+PWM0P1_IRQHandler
+PWM0P2_IRQHandler
+BRAKE1_IRQHandler
+PWM1P0_IRQHandler
+PWM1P1_IRQHandler
+PWM1P2_IRQHandler
+TMR0_IRQHandler
+TMR1_IRQHandler
+TMR2_IRQHandler
+TMR3_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+PDMA_IRQHandler
+DAC_IRQHandler
+EADC00_IRQHandler
+EADC01_IRQHandler
+ACMP01_IRQHandler
+EADC02_IRQHandler
+EADC03_IRQHandler
+UART2_IRQHandler
+UART3_IRQHandler
+QSPI1_IRQHandler
+SPI1_IRQHandler
+SPI2_IRQHandler
+USBD_IRQHandler
+OHCI_IRQHandler
+USBOTG_IRQHandler
+CAN0_IRQHandler
+CAN1_IRQHandler
+SC0_IRQHandler
+SC1_IRQHandler
+SC2_IRQHandler
+SPI3_IRQHandler
+SDH0_IRQHandler
+USBD20_IRQHandler
+EMAC_TX_IRQHandler
+EMAC_RX_IRQHandler
+I2S0_IRQHandler
+OPA0_IRQHandler
+CRYPTO_IRQHandler
+GPG_IRQHandler
+EINT6_IRQHandler
+UART4_IRQHandler
+UART5_IRQHandler
+USCI0_IRQHandler
+USCI1_IRQHandler
+BPWM0_IRQHandler
+BPWM1_IRQHandler
+SPIM_IRQHandler
+CCAP_IRQHandler
+I2C2_IRQHandler
+QEI0_IRQHandler
+QEI1_IRQHandler
+ECAP0_IRQHandler
+ECAP1_IRQHandler
+GPH_IRQHandler
+EINT7_IRQHandler
+SDH1_IRQHandler
+EHCI_IRQHandler
+USBOTG20_IRQHandler
+TRNG_IRQHandler
+UART6_IRQHandler
+UART7_IRQHandler
+EADC10_IRQHandler
+EADC11_IRQHandler
+EADC12_IRQHandler
+EADC13_IRQHandler
+CAN2_IRQHandler
+Default_Handler
+        B Default_Handler
+
+
+
+
+        END
+;/*** (C) COPYRIGHT 2016 Nuvoton Technology Corp. ***/

--- a/SampleCode/ISP/ISP_HID/GCC/Makefile
+++ b/SampleCode/ISP/ISP_HID/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_HID/GCC/Makefile
+++ b/SampleCode/ISP/ISP_HID/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_HID
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_HID/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_HID/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+#STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_HID/fmc_user.c
+++ b/SampleCode/ISP/ISP_HID/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_HID/fmc_user.h
+++ b/SampleCode/ISP/ISP_HID/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_HID/hid_transfer.c
+++ b/SampleCode/ISP/ISP_HID/hid_transfer.c
@@ -13,7 +13,12 @@
 #include "hid_transfer.h"
 
 uint8_t volatile g_u8EP2Ready = 0;
-__align(4) uint8_t usb_rcvbuf[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t usb_rcvbuf[64];
+#else
+__attribute__((aligned(4))) uint8_t usb_rcvbuf[64];
+#endif
 uint8_t bUsbDataReady;
 
 void USBD_IRQHandler(void)
@@ -145,7 +150,12 @@ void USBD_IRQHandler(void)
     }
 }
 
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 void EP2_Handler(void)  /* Interrupt IN handler */
 {
     uint8_t *ptr;

--- a/SampleCode/ISP/ISP_HID/isp_user.c
+++ b/SampleCode/ISP/ISP_HID/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_HID/isp_user.h
+++ b/SampleCode/ISP/ISP_HID/isp_user.h
@@ -42,7 +42,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_HID/startup_M480_user_GCC.S
+++ b/SampleCode/ISP/ISP_HID/startup_M480_user_GCC.S
@@ -1,0 +1,367 @@
+/****************************************************************************//**
+ * @file     startup_M480.S
+ * @version  V1.00
+ * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+
+
+	.syntax	unified
+	.arch	armv7-m
+
+	.section .stack
+	.align	3
+#ifdef __STACK_SIZE
+	.equ	Stack_Size, __STACK_SIZE
+#else
+	.equ	Stack_Size, 0x00000800
+#endif
+	.globl	__StackTop
+	.globl	__StackLimit
+__StackLimit:
+	.space	Stack_Size
+	.size	__StackLimit, . - __StackLimit
+__StackTop:
+	.size	__StackTop, . - __StackTop
+
+	.section .heap
+	.align	3
+#ifdef __HEAP_SIZE
+	.equ	Heap_Size, __HEAP_SIZE
+#else
+	.equ	Heap_Size, 0x00000100
+#endif
+	.globl	__HeapBase
+	.globl	__HeapLimit
+__HeapBase:
+	.if	Heap_Size
+	.space	Heap_Size
+	.endif
+	.size	__HeapBase, . - __HeapBase
+__HeapLimit:
+	.size	__HeapLimit, . - __HeapLimit
+
+	.section .vectors
+	.align	2
+	.globl	__Vectors
+__Vectors:
+	.long	__StackTop            /* Top of Stack */
+	.long	Reset_Handler         /* Reset Handler */
+	.long	NMI_Handler           /* NMI Handler */
+	.long	HardFault_Handler     /* Hard Fault Handler */
+	.long	MemManage_Handler     /* MPU Fault Handler */
+	.long	BusFault_Handler      /* Bus Fault Handler */
+	.long	UsageFault_Handler    /* Usage Fault Handler */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	SVC_Handler           /* SVCall Handler */
+	.long	DebugMon_Handler      /* Debug Monitor Handler */
+	.long	0                     /* Reserved */
+	.long	PendSV_Handler        /* PendSV Handler */
+	.long	SysTick_Handler       /* SysTick Handler */
+
+	/* External interrupts */
+
+
+	.size	__Vectors, . - __Vectors
+
+	.text
+	.thumb
+	.thumb_func
+	.align	2
+	.globl	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+/*  Firstly it copies data from read only memory to RAM. There are two schemes
+ *  to copy. One can copy more than one sections. Another can only copy
+ *  one section.  The former scheme needs more instructions and read-only
+ *  data to implement than the latter.
+ *  Macro __STARTUP_COPY_MULTIPLE is used to choose between two schemes.  */
+
+#ifdef __STARTUP_COPY_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of triplets, each of which specify:
+ *    offset 0: LMA of start of a section to copy from
+ *    offset 4: VMA of start of a section to copy to
+ *    offset 8: size of the section to copy. Must be multiply of 4
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r4, =__copy_table_start__
+	ldr	r5, =__copy_table_end__
+
+.L_loop0:
+	cmp	r4, r5
+	bge	.L_loop0_done
+	ldr	r1, [r4]
+	ldr	r2, [r4, #4]
+	ldr	r3, [r4, #8]
+
+.L_loop0_0:
+	subs	r3, #4
+	ittt	ge
+	ldrge	r0, [r1, r3]
+	strge	r0, [r2, r3]
+	bge	.L_loop0_0
+
+	adds	r4, #12
+	b	.L_loop0
+
+.L_loop0_done:
+#else
+/*  Single section scheme.
+ *
+ *  The ranges of copy from/to are specified by following symbols
+ *    __etext: LMA of start of the section to copy from. Usually end of text
+ *    __data_start__: VMA of start of the section to copy to
+ *    __data_end__: VMA of end of the section to copy to
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__etext
+	ldr	r2, =__data_start__
+	ldr	r3, =__data_end__
+
+.L_loop1:
+	cmp	r2, r3
+	ittt	lt
+	ldrlt	r0, [r1], #4
+	strlt	r0, [r2], #4
+	blt	.L_loop1
+#endif /*__STARTUP_COPY_MULTIPLE */
+
+/*  This part of work usually is done in C library startup code. Otherwise,
+ *  define this macro to enable it in this startup.
+ *
+ *  There are two schemes too. One can clear multiple BSS sections. Another
+ *  can only clear one section. The former is more size expensive than the
+ *  latter.
+ *
+ *  Define macro __STARTUP_CLEAR_BSS_MULTIPLE to choose the former.
+ *  Otherwise efine macro __STARTUP_CLEAR_BSS to choose the later.
+ */
+#ifdef __STARTUP_CLEAR_BSS_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of tuples specifying:
+ *    offset 0: Start of a BSS section
+ *    offset 4: Size of this BSS section. Must be multiply of 4
+ */
+	ldr	r3, =__zero_table_start__
+	ldr	r4, =__zero_table_end__
+
+.L_loop2:
+	cmp	r3, r4
+	bge	.L_loop2_done
+	ldr	r1, [r3]
+	ldr	r2, [r3, #4]
+	movs	r0, 0
+
+.L_loop2_0:
+	subs	r2, #4
+	itt	ge
+	strge	r0, [r1, r2]
+	bge	.L_loop2_0
+
+	adds	r3, #8
+	b	.L_loop2
+.L_loop2_done:
+#elif defined (__STARTUP_CLEAR_BSS)
+/*  Single BSS section scheme.
+ *
+ *  The BSS section is specified by following symbols
+ *    __bss_start__: start of the BSS section.
+ *    __bss_end__: end of the BSS section.
+ *
+ *  Both addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__bss_start__
+	ldr	r2, =__bss_end__
+
+	movs	r0, 0
+.L_loop3:
+	cmp	r1, r2
+	itt	lt
+	strlt	r0, [r1], #4
+	blt	.L_loop3
+#endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
+
+/*  Unlock Register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0x59
+	str	r1, [r0]
+	ldr	r1, =0x16
+	str	r1, [r0]
+	ldr	r1, =0x88
+	str	r1, [r0]
+
+#ifndef ENABLE_SPIM_CACHE
+	ldr	r0, =0x40000200            /* R0 = Clock Controller Register Base Address */
+	ldr	r1, [r0,#0x4]              /* R1 = 0x40000204  (AHBCLK) */
+	orr	r1, r1, #0x4000
+	str	r1, [r0,#0x4]              /* CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk; */
+
+	ldr	r0, =0x40007000            /* R0 = SPIM Register Base Address */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1,#2                  /* R1 |= SPIM_CTL1_CACHEOFF_Msk */
+	str	r1, [r0,#4]                /* _SPIM_DISABLE_CACHE() */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1, #4                 /* R1 |= SPIM_CTL1_CCMEN_Msk */
+	str	r1, [r0,#4]                /* _SPIM_ENABLE_CCM() */
+#endif
+
+#ifndef __NO_SYSTEM_INIT
+	bl	SystemInit
+#endif
+
+/* Init POR */
+#if 0
+	ldr	r0, =0x40000024
+	ldr	r1, =0x00005AA5
+	str	r1, [r0]
+#endif
+
+/* Lock register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0
+	str	r1, [r0]
+
+#ifndef __START
+#define __START _start
+#endif
+	bl	__START
+
+	.pool
+	.size	Reset_Handler, . - Reset_Handler
+
+	.align	1
+	.thumb_func
+	.weak	Default_Handler
+	.type	Default_Handler, %function
+Default_Handler:
+	b	.
+	.size	Default_Handler, . - Default_Handler
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+	.macro	def_irq_handler	handler_name
+	.weak	\handler_name
+	.set	\handler_name, Default_Handler
+	.endm
+
+	def_irq_handler	NMI_Handler
+	def_irq_handler	HardFault_Handler
+	def_irq_handler	MemManage_Handler
+	def_irq_handler	BusFault_Handler
+	def_irq_handler	UsageFault_Handler
+	def_irq_handler	SVC_Handler
+	def_irq_handler	DebugMon_Handler
+	def_irq_handler	PendSV_Handler
+	def_irq_handler	SysTick_Handler
+
+	def_irq_handler	BOD_IRQHandler
+	def_irq_handler	IRC_IRQHandler
+	def_irq_handler	PWRWU_IRQHandler
+	def_irq_handler	RAMPE_IRQHandler
+	def_irq_handler	CKFAIL_IRQHandler
+	def_irq_handler	RTC_IRQHandler
+	def_irq_handler	TAMPER_IRQHandler
+	def_irq_handler	WDT_IRQHandler
+	def_irq_handler	WWDT_IRQHandler
+	def_irq_handler	EINT0_IRQHandler
+	def_irq_handler	EINT1_IRQHandler
+	def_irq_handler	EINT2_IRQHandler
+	def_irq_handler	EINT3_IRQHandler
+	def_irq_handler	EINT4_IRQHandler
+	def_irq_handler	EINT5_IRQHandler
+	def_irq_handler	GPA_IRQHandler
+	def_irq_handler	GPB_IRQHandler
+	def_irq_handler	GPC_IRQHandler
+	def_irq_handler	GPD_IRQHandler
+	def_irq_handler	GPE_IRQHandler
+	def_irq_handler	GPF_IRQHandler
+	def_irq_handler	QSPI0_IRQHandler
+	def_irq_handler	SPI0_IRQHandler
+	def_irq_handler	BRAKE0_IRQHandler
+	def_irq_handler	EPWM0P0_IRQHandler
+	def_irq_handler	EPWM0P1_IRQHandler
+	def_irq_handler	EPWM0P2_IRQHandler
+	def_irq_handler	BRAKE1_IRQHandler
+	def_irq_handler	EPWM1P0_IRQHandler
+	def_irq_handler	EPWM1P1_IRQHandler
+	def_irq_handler	EPWM1P2_IRQHandler
+	def_irq_handler	TMR0_IRQHandler
+	def_irq_handler	TMR1_IRQHandler
+	def_irq_handler	TMR2_IRQHandler
+	def_irq_handler	TMR3_IRQHandler
+	def_irq_handler	UART0_IRQHandler
+	def_irq_handler	UART1_IRQHandler
+	def_irq_handler	I2C0_IRQHandler
+	def_irq_handler	I2C1_IRQHandler
+	def_irq_handler	PDMA_IRQHandler
+	def_irq_handler	DAC_IRQHandler
+	def_irq_handler	EADC00_IRQHandler
+	def_irq_handler	EADC01_IRQHandler
+	def_irq_handler	ACMP01_IRQHandler
+	def_irq_handler	EADC02_IRQHandler
+	def_irq_handler	EADC03_IRQHandler
+	def_irq_handler	UART2_IRQHandler
+	def_irq_handler	UART3_IRQHandler
+	def_irq_handler	QSPI1_IRQHandler
+	def_irq_handler	SPI1_IRQHandler
+	def_irq_handler	SPI2_IRQHandler
+	def_irq_handler	USBD_IRQHandler
+	def_irq_handler	OHCI_IRQHandler
+	def_irq_handler	USBOTG_IRQHandler
+	def_irq_handler	CAN0_IRQHandler
+	def_irq_handler	CAN1_IRQHandler
+	def_irq_handler	SC0_IRQHandler
+	def_irq_handler	SC1_IRQHandler
+	def_irq_handler	SC2_IRQHandler
+	def_irq_handler	SPI3_IRQHandler
+	def_irq_handler	SDH0_IRQHandler
+	def_irq_handler	USBD20_IRQHandler
+	def_irq_handler	EMAC_TX_IRQHandler
+	def_irq_handler	EMAC_RX_IRQHandler
+	def_irq_handler	I2S0_IRQHandler
+	def_irq_handler	OPA0_IRQHandler
+	def_irq_handler	CRYPTO_IRQHandler
+	def_irq_handler	GPG_IRQHandler
+	def_irq_handler	EINT6_IRQHandler
+	def_irq_handler	UART4_IRQHandler
+	def_irq_handler	UART5_IRQHandler
+	def_irq_handler	USCI0_IRQHandler
+	def_irq_handler	USCI1_IRQHandler
+	def_irq_handler	BPWM0_IRQHandler
+	def_irq_handler	BPWM1_IRQHandler
+	def_irq_handler	SPIM_IRQHandler
+	def_irq_handler CCAP_IRQHandler
+	def_irq_handler	I2C2_IRQHandler
+	def_irq_handler	QEI0_IRQHandler
+	def_irq_handler	QEI1_IRQHandler
+	def_irq_handler	ECAP0_IRQHandler
+	def_irq_handler	ECAP1_IRQHandler
+	def_irq_handler	GPH_IRQHandler
+	def_irq_handler	EINT7_IRQHandler
+	def_irq_handler	SDH1_IRQHandler
+	def_irq_handler	EHCI_IRQHandler
+	def_irq_handler	USBOTG20_IRQHandler
+	def_irq_handler	TRNG_IRQHandler
+	def_irq_handler	UART6_IRQHandler
+	def_irq_handler	UART7_IRQHandler
+	def_irq_handler	EADC10_IRQHandler
+	def_irq_handler	EADC11_IRQHandler
+	def_irq_handler	EADC12_IRQHandler
+	def_irq_handler	EADC13_IRQHandler
+	def_irq_handler	CAN2_IRQHandler
+
+	.end

--- a/SampleCode/ISP/ISP_HID/startup_M480_user_IAR.s
+++ b/SampleCode/ISP/ISP_HID/startup_M480_user_IAR.s
@@ -1,0 +1,344 @@
+;/******************************************************************************
+; * @file     startup_M480.s
+; * @version  V1.00
+; * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+; *
+; * SPDX-License-Identifier: Apache-2.0
+; * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+;*****************************************************************************/
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  HardFault_Handler
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+        PUBLIC  __vector_table_0x1c
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler
+
+        DCD     NMI_Handler
+        DCD     HardFault_Handler
+        DCD     MemManage_Handler
+        DCD     BusFault_Handler
+        DCD     UsageFault_Handler
+__vector_table_0x1c
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     SVC_Handler
+        DCD     DebugMon_Handler
+        DCD     0
+        DCD     PendSV_Handler
+        DCD     SysTick_Handler
+
+        ; External Interrupts
+
+__Vectors_End
+
+__Vectors       EQU   __vector_table
+__Vectors_Size  EQU   __Vectors_End - __Vectors
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:REORDER:NOROOT(2)
+Reset_Handler
+        ; Unlock Register
+        LDR     R0, =0x40000100
+        LDR     R1, =0x59
+        STR     R1, [R0]
+        LDR     R1, =0x16
+        STR     R1, [R0]
+        LDR     R1, =0x88
+        STR     R1, [R0]
+
+	#ifndef ENABLE_SPIM_CACHE
+        LDR     R0, =0x40000200            ; R0 = Clock Controller Register Base Address
+        LDR     R1, [R0,#0x4]              ; R1 = 0x40000204  (AHBCLK)
+        ORR     R1, R1, #0x4000              
+        STR     R1, [R0,#0x4]              ; CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk;
+                
+        LDR     R0, =0x40007000            ; R0 = SPIM Register Base Address
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1,#2                  ; R1 |= SPIM_CTL1_CACHEOFF_Msk
+        STR     R1, [R0,#4]                ; _SPIM_DISABLE_CACHE()
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1, #4                 ; R1 |= SPIM_CTL1_CCMEN_Msk
+        STR     R1, [R0,#4]                ; _SPIM_ENABLE_CCM()
+	#endif
+
+        LDR     R0, =SystemInit
+        BLX     R0
+
+        ; Init POR
+        ; LDR     R2, =0x40000024
+        ; LDR     R1, =0x00005AA5
+        ; STR     R1, [R2]
+
+        ; Lock register
+        LDR     R0, =0x40000100
+        MOVS    R1, #0
+        STR     R1, [R0]
+
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+NMI_Handler
+        B NMI_Handler
+
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+UsageFault_Handler
+        B UsageFault_Handler
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SVC_Handler
+        B SVC_Handler
+
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+DebugMon_Handler
+        B DebugMon_Handler
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+PendSV_Handler
+        B PendSV_Handler
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SysTick_Handler
+        B SysTick_Handler
+
+        PUBWEAK  BOD_IRQHandler
+        PUBWEAK  IRC_IRQHandler
+        PUBWEAK  PWRWU_IRQHandler
+        PUBWEAK  RAMPE_IRQHandler
+        PUBWEAK  CKFAIL_IRQHandler
+        PUBWEAK  RTC_IRQHandler
+        PUBWEAK  TAMPER_IRQHandler
+        PUBWEAK  WDT_IRQHandler
+        PUBWEAK  WWDT_IRQHandler
+        PUBWEAK  EINT0_IRQHandler
+        PUBWEAK  EINT1_IRQHandler
+        PUBWEAK  EINT2_IRQHandler
+        PUBWEAK  EINT3_IRQHandler
+        PUBWEAK  EINT4_IRQHandler
+        PUBWEAK  EINT5_IRQHandler
+        PUBWEAK  GPA_IRQHandler
+        PUBWEAK  GPB_IRQHandler
+        PUBWEAK  GPC_IRQHandler
+        PUBWEAK  GPD_IRQHandler
+        PUBWEAK  GPE_IRQHandler
+        PUBWEAK  GPF_IRQHandler
+        PUBWEAK  QSPI0_IRQHandler
+        PUBWEAK  SPI0_IRQHandler
+        PUBWEAK  BRAKE0_IRQHandler
+        PUBWEAK  PWM0P0_IRQHandler
+        PUBWEAK  PWM0P1_IRQHandler
+        PUBWEAK  PWM0P2_IRQHandler
+        PUBWEAK  BRAKE1_IRQHandler
+        PUBWEAK  PWM1P0_IRQHandler
+        PUBWEAK  PWM1P1_IRQHandler
+        PUBWEAK  PWM1P2_IRQHandler
+        PUBWEAK  TMR0_IRQHandler
+        PUBWEAK  TMR1_IRQHandler
+        PUBWEAK  TMR2_IRQHandler
+        PUBWEAK  TMR3_IRQHandler
+        PUBWEAK  UART0_IRQHandler
+        PUBWEAK  UART1_IRQHandler
+        PUBWEAK  I2C0_IRQHandler
+        PUBWEAK  I2C1_IRQHandler
+        PUBWEAK  PDMA_IRQHandler
+        PUBWEAK  DAC_IRQHandler
+        PUBWEAK  EADC00_IRQHandler
+        PUBWEAK  EADC01_IRQHandler
+        PUBWEAK  ACMP01_IRQHandler
+        PUBWEAK  EADC02_IRQHandler
+        PUBWEAK  EADC03_IRQHandler
+        PUBWEAK  UART2_IRQHandler
+        PUBWEAK  UART3_IRQHandler
+        PUBWEAK  QSPI1_IRQHandler
+        PUBWEAK  SPI1_IRQHandler
+        PUBWEAK  SPI2_IRQHandler
+        PUBWEAK  USBD_IRQHandler
+        PUBWEAK  OHCI_IRQHandler
+        PUBWEAK  USBOTG_IRQHandler
+        PUBWEAK  CAN0_IRQHandler
+        PUBWEAK  CAN1_IRQHandler
+        PUBWEAK  SC0_IRQHandler
+        PUBWEAK  SC1_IRQHandler
+        PUBWEAK  SC2_IRQHandler
+        PUBWEAK  SPI3_IRQHandler
+        PUBWEAK  SDH0_IRQHandler
+        PUBWEAK  USBD20_IRQHandler
+        PUBWEAK  EMAC_TX_IRQHandler
+        PUBWEAK  EMAC_RX_IRQHandler
+        PUBWEAK  I2S0_IRQHandler
+        PUBWEAK  OPA0_IRQHandler
+        PUBWEAK  CRYPTO_IRQHandler
+        PUBWEAK  GPG_IRQHandler
+        PUBWEAK  EINT6_IRQHandler
+        PUBWEAK  UART4_IRQHandler
+        PUBWEAK  UART5_IRQHandler
+        PUBWEAK  USCI0_IRQHandler
+        PUBWEAK  USCI1_IRQHandler
+        PUBWEAK  BPWM0_IRQHandler
+        PUBWEAK  BPWM1_IRQHandler
+        PUBWEAK  SPIM_IRQHandler
+        PUBWEAK  CCAP_IRQHandler
+        PUBWEAK  I2C2_IRQHandler
+        PUBWEAK  QEI0_IRQHandler
+        PUBWEAK  QEI1_IRQHandler
+        PUBWEAK  ECAP0_IRQHandler
+        PUBWEAK  ECAP1_IRQHandler
+        PUBWEAK  GPH_IRQHandler
+        PUBWEAK  EINT7_IRQHandler
+        PUBWEAK  SDH1_IRQHandler
+        PUBWEAK  EHCI_IRQHandler
+        PUBWEAK  USBOTG20_IRQHandler
+        PUBWEAK  TRNG_IRQHandler
+        PUBWEAK  UART6_IRQHandler
+        PUBWEAK  UART7_IRQHandler
+        PUBWEAK  EADC10_IRQHandler
+        PUBWEAK  EADC11_IRQHandler
+        PUBWEAK  EADC12_IRQHandler
+        PUBWEAK  EADC13_IRQHandler
+        PUBWEAK  CAN2_IRQHandler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+
+BOD_IRQHandler
+IRC_IRQHandler
+PWRWU_IRQHandler
+RAMPE_IRQHandler
+CKFAIL_IRQHandler
+RTC_IRQHandler
+TAMPER_IRQHandler
+WDT_IRQHandler
+WWDT_IRQHandler
+EINT0_IRQHandler
+EINT1_IRQHandler
+EINT2_IRQHandler
+EINT3_IRQHandler
+EINT4_IRQHandler
+EINT5_IRQHandler
+GPA_IRQHandler
+GPB_IRQHandler
+GPC_IRQHandler
+GPD_IRQHandler
+GPE_IRQHandler
+GPF_IRQHandler
+QSPI0_IRQHandler
+SPI0_IRQHandler
+BRAKE0_IRQHandler
+PWM0P0_IRQHandler
+PWM0P1_IRQHandler
+PWM0P2_IRQHandler
+BRAKE1_IRQHandler
+PWM1P0_IRQHandler
+PWM1P1_IRQHandler
+PWM1P2_IRQHandler
+TMR0_IRQHandler
+TMR1_IRQHandler
+TMR2_IRQHandler
+TMR3_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+PDMA_IRQHandler
+DAC_IRQHandler
+EADC00_IRQHandler
+EADC01_IRQHandler
+ACMP01_IRQHandler
+EADC02_IRQHandler
+EADC03_IRQHandler
+UART2_IRQHandler
+UART3_IRQHandler
+QSPI1_IRQHandler
+SPI1_IRQHandler
+SPI2_IRQHandler
+USBD_IRQHandler
+OHCI_IRQHandler
+USBOTG_IRQHandler
+CAN0_IRQHandler
+CAN1_IRQHandler
+SC0_IRQHandler
+SC1_IRQHandler
+SC2_IRQHandler
+SPI3_IRQHandler
+SDH0_IRQHandler
+USBD20_IRQHandler
+EMAC_TX_IRQHandler
+EMAC_RX_IRQHandler
+I2S0_IRQHandler
+OPA0_IRQHandler
+CRYPTO_IRQHandler
+GPG_IRQHandler
+EINT6_IRQHandler
+UART4_IRQHandler
+UART5_IRQHandler
+USCI0_IRQHandler
+USCI1_IRQHandler
+BPWM0_IRQHandler
+BPWM1_IRQHandler
+SPIM_IRQHandler
+CCAP_IRQHandler
+I2C2_IRQHandler
+QEI0_IRQHandler
+QEI1_IRQHandler
+ECAP0_IRQHandler
+ECAP1_IRQHandler
+GPH_IRQHandler
+EINT7_IRQHandler
+SDH1_IRQHandler
+EHCI_IRQHandler
+USBOTG20_IRQHandler
+TRNG_IRQHandler
+UART6_IRQHandler
+UART7_IRQHandler
+EADC10_IRQHandler
+EADC11_IRQHandler
+EADC12_IRQHandler
+EADC13_IRQHandler
+CAN2_IRQHandler
+Default_Handler
+        B Default_Handler
+
+
+
+
+        END
+;/*** (C) COPYRIGHT 2016 Nuvoton Technology Corp. ***/

--- a/SampleCode/ISP/ISP_HID_20/GCC/Makefile
+++ b/SampleCode/ISP/ISP_HID_20/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_HID_20
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_HID_20/GCC/Makefile
+++ b/SampleCode/ISP/ISP_HID_20/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_HID_20/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_HID_20/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+#STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_HID_20/fmc_user.c
+++ b/SampleCode/ISP/ISP_HID_20/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_HID_20/fmc_user.h
+++ b/SampleCode/ISP/ISP_HID_20/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_HID_20/hid_transfer.c
+++ b/SampleCode/ISP/ISP_HID_20/hid_transfer.c
@@ -17,7 +17,12 @@ uint8_t volatile g_u8EPAReady = 0;
 uint32_t g_u32EpAMaxPacketSize;
 uint32_t g_u32EpBMaxPacketSize;
 
-__align(4) uint8_t usb_rcvbuf[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t usb_rcvbuf[64];
+#else
+__attribute__((aligned(4))) uint8_t usb_rcvbuf[64];
+#endif
 uint8_t bUsbDataReady;
 
 void USBD20_IRQHandler(void)
@@ -173,7 +178,12 @@ void USBD20_IRQHandler(void)
     }
 }
 
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 void EPA_Handler(void)  /* Interrupt IN handler */
 {
     uint32_t i;

--- a/SampleCode/ISP/ISP_HID_20/isp_user.c
+++ b/SampleCode/ISP/ISP_HID_20/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_HID_20/isp_user.h
+++ b/SampleCode/ISP/ISP_HID_20/isp_user.h
@@ -42,7 +42,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_HID_20/startup_M480_user_GCC.S
+++ b/SampleCode/ISP/ISP_HID_20/startup_M480_user_GCC.S
@@ -1,0 +1,367 @@
+/****************************************************************************//**
+ * @file     startup_M480.S
+ * @version  V1.00
+ * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+
+
+	.syntax	unified
+	.arch	armv7-m
+
+	.section .stack
+	.align	3
+#ifdef __STACK_SIZE
+	.equ	Stack_Size, __STACK_SIZE
+#else
+	.equ	Stack_Size, 0x00000800
+#endif
+	.globl	__StackTop
+	.globl	__StackLimit
+__StackLimit:
+	.space	Stack_Size
+	.size	__StackLimit, . - __StackLimit
+__StackTop:
+	.size	__StackTop, . - __StackTop
+
+	.section .heap
+	.align	3
+#ifdef __HEAP_SIZE
+	.equ	Heap_Size, __HEAP_SIZE
+#else
+	.equ	Heap_Size, 0x00000100
+#endif
+	.globl	__HeapBase
+	.globl	__HeapLimit
+__HeapBase:
+	.if	Heap_Size
+	.space	Heap_Size
+	.endif
+	.size	__HeapBase, . - __HeapBase
+__HeapLimit:
+	.size	__HeapLimit, . - __HeapLimit
+
+	.section .vectors
+	.align	2
+	.globl	__Vectors
+__Vectors:
+	.long	__StackTop            /* Top of Stack */
+	.long	Reset_Handler         /* Reset Handler */
+	.long	NMI_Handler           /* NMI Handler */
+	.long	HardFault_Handler     /* Hard Fault Handler */
+	.long	MemManage_Handler     /* MPU Fault Handler */
+	.long	BusFault_Handler      /* Bus Fault Handler */
+	.long	UsageFault_Handler    /* Usage Fault Handler */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	0                     /* Reserved */
+	.long	SVC_Handler           /* SVCall Handler */
+	.long	DebugMon_Handler      /* Debug Monitor Handler */
+	.long	0                     /* Reserved */
+	.long	PendSV_Handler        /* PendSV Handler */
+	.long	SysTick_Handler       /* SysTick Handler */
+
+	/* External interrupts */
+
+
+	.size	__Vectors, . - __Vectors
+
+	.text
+	.thumb
+	.thumb_func
+	.align	2
+	.globl	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+/*  Firstly it copies data from read only memory to RAM. There are two schemes
+ *  to copy. One can copy more than one sections. Another can only copy
+ *  one section.  The former scheme needs more instructions and read-only
+ *  data to implement than the latter.
+ *  Macro __STARTUP_COPY_MULTIPLE is used to choose between two schemes.  */
+
+#ifdef __STARTUP_COPY_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of triplets, each of which specify:
+ *    offset 0: LMA of start of a section to copy from
+ *    offset 4: VMA of start of a section to copy to
+ *    offset 8: size of the section to copy. Must be multiply of 4
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r4, =__copy_table_start__
+	ldr	r5, =__copy_table_end__
+
+.L_loop0:
+	cmp	r4, r5
+	bge	.L_loop0_done
+	ldr	r1, [r4]
+	ldr	r2, [r4, #4]
+	ldr	r3, [r4, #8]
+
+.L_loop0_0:
+	subs	r3, #4
+	ittt	ge
+	ldrge	r0, [r1, r3]
+	strge	r0, [r2, r3]
+	bge	.L_loop0_0
+
+	adds	r4, #12
+	b	.L_loop0
+
+.L_loop0_done:
+#else
+/*  Single section scheme.
+ *
+ *  The ranges of copy from/to are specified by following symbols
+ *    __etext: LMA of start of the section to copy from. Usually end of text
+ *    __data_start__: VMA of start of the section to copy to
+ *    __data_end__: VMA of end of the section to copy to
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__etext
+	ldr	r2, =__data_start__
+	ldr	r3, =__data_end__
+
+.L_loop1:
+	cmp	r2, r3
+	ittt	lt
+	ldrlt	r0, [r1], #4
+	strlt	r0, [r2], #4
+	blt	.L_loop1
+#endif /*__STARTUP_COPY_MULTIPLE */
+
+/*  This part of work usually is done in C library startup code. Otherwise,
+ *  define this macro to enable it in this startup.
+ *
+ *  There are two schemes too. One can clear multiple BSS sections. Another
+ *  can only clear one section. The former is more size expensive than the
+ *  latter.
+ *
+ *  Define macro __STARTUP_CLEAR_BSS_MULTIPLE to choose the former.
+ *  Otherwise efine macro __STARTUP_CLEAR_BSS to choose the later.
+ */
+#ifdef __STARTUP_CLEAR_BSS_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of tuples specifying:
+ *    offset 0: Start of a BSS section
+ *    offset 4: Size of this BSS section. Must be multiply of 4
+ */
+	ldr	r3, =__zero_table_start__
+	ldr	r4, =__zero_table_end__
+
+.L_loop2:
+	cmp	r3, r4
+	bge	.L_loop2_done
+	ldr	r1, [r3]
+	ldr	r2, [r3, #4]
+	movs	r0, 0
+
+.L_loop2_0:
+	subs	r2, #4
+	itt	ge
+	strge	r0, [r1, r2]
+	bge	.L_loop2_0
+
+	adds	r3, #8
+	b	.L_loop2
+.L_loop2_done:
+#elif defined (__STARTUP_CLEAR_BSS)
+/*  Single BSS section scheme.
+ *
+ *  The BSS section is specified by following symbols
+ *    __bss_start__: start of the BSS section.
+ *    __bss_end__: end of the BSS section.
+ *
+ *  Both addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__bss_start__
+	ldr	r2, =__bss_end__
+
+	movs	r0, 0
+.L_loop3:
+	cmp	r1, r2
+	itt	lt
+	strlt	r0, [r1], #4
+	blt	.L_loop3
+#endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
+
+/*  Unlock Register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0x59
+	str	r1, [r0]
+	ldr	r1, =0x16
+	str	r1, [r0]
+	ldr	r1, =0x88
+	str	r1, [r0]
+
+#ifndef ENABLE_SPIM_CACHE
+	ldr	r0, =0x40000200            /* R0 = Clock Controller Register Base Address */
+	ldr	r1, [r0,#0x4]              /* R1 = 0x40000204  (AHBCLK) */
+	orr	r1, r1, #0x4000
+	str	r1, [r0,#0x4]              /* CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk; */
+
+	ldr	r0, =0x40007000            /* R0 = SPIM Register Base Address */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1,#2                  /* R1 |= SPIM_CTL1_CACHEOFF_Msk */
+	str	r1, [r0,#4]                /* _SPIM_DISABLE_CACHE() */
+	ldr	r1, [r0,#4]                /* R1 = SPIM->CTL1 */
+	orr	r1, r1, #4                 /* R1 |= SPIM_CTL1_CCMEN_Msk */
+	str	r1, [r0,#4]                /* _SPIM_ENABLE_CCM() */
+#endif
+
+#ifndef __NO_SYSTEM_INIT
+	bl	SystemInit
+#endif
+
+/* Init POR */
+#if 0
+	ldr	r0, =0x40000024
+	ldr	r1, =0x00005AA5
+	str	r1, [r0]
+#endif
+
+/* Lock register */
+	ldr	r0, =0x40000100
+	ldr	r1, =0
+	str	r1, [r0]
+
+#ifndef __START
+#define __START _start
+#endif
+	bl	__START
+
+	.pool
+	.size	Reset_Handler, . - Reset_Handler
+
+	.align	1
+	.thumb_func
+	.weak	Default_Handler
+	.type	Default_Handler, %function
+Default_Handler:
+	b	.
+	.size	Default_Handler, . - Default_Handler
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+	.macro	def_irq_handler	handler_name
+	.weak	\handler_name
+	.set	\handler_name, Default_Handler
+	.endm
+
+	def_irq_handler	NMI_Handler
+	def_irq_handler	HardFault_Handler
+	def_irq_handler	MemManage_Handler
+	def_irq_handler	BusFault_Handler
+	def_irq_handler	UsageFault_Handler
+	def_irq_handler	SVC_Handler
+	def_irq_handler	DebugMon_Handler
+	def_irq_handler	PendSV_Handler
+	def_irq_handler	SysTick_Handler
+
+	def_irq_handler	BOD_IRQHandler
+	def_irq_handler	IRC_IRQHandler
+	def_irq_handler	PWRWU_IRQHandler
+	def_irq_handler	RAMPE_IRQHandler
+	def_irq_handler	CKFAIL_IRQHandler
+	def_irq_handler	RTC_IRQHandler
+	def_irq_handler	TAMPER_IRQHandler
+	def_irq_handler	WDT_IRQHandler
+	def_irq_handler	WWDT_IRQHandler
+	def_irq_handler	EINT0_IRQHandler
+	def_irq_handler	EINT1_IRQHandler
+	def_irq_handler	EINT2_IRQHandler
+	def_irq_handler	EINT3_IRQHandler
+	def_irq_handler	EINT4_IRQHandler
+	def_irq_handler	EINT5_IRQHandler
+	def_irq_handler	GPA_IRQHandler
+	def_irq_handler	GPB_IRQHandler
+	def_irq_handler	GPC_IRQHandler
+	def_irq_handler	GPD_IRQHandler
+	def_irq_handler	GPE_IRQHandler
+	def_irq_handler	GPF_IRQHandler
+	def_irq_handler	QSPI0_IRQHandler
+	def_irq_handler	SPI0_IRQHandler
+	def_irq_handler	BRAKE0_IRQHandler
+	def_irq_handler	EPWM0P0_IRQHandler
+	def_irq_handler	EPWM0P1_IRQHandler
+	def_irq_handler	EPWM0P2_IRQHandler
+	def_irq_handler	BRAKE1_IRQHandler
+	def_irq_handler	EPWM1P0_IRQHandler
+	def_irq_handler	EPWM1P1_IRQHandler
+	def_irq_handler	EPWM1P2_IRQHandler
+	def_irq_handler	TMR0_IRQHandler
+	def_irq_handler	TMR1_IRQHandler
+	def_irq_handler	TMR2_IRQHandler
+	def_irq_handler	TMR3_IRQHandler
+	def_irq_handler	UART0_IRQHandler
+	def_irq_handler	UART1_IRQHandler
+	def_irq_handler	I2C0_IRQHandler
+	def_irq_handler	I2C1_IRQHandler
+	def_irq_handler	PDMA_IRQHandler
+	def_irq_handler	DAC_IRQHandler
+	def_irq_handler	EADC00_IRQHandler
+	def_irq_handler	EADC01_IRQHandler
+	def_irq_handler	ACMP01_IRQHandler
+	def_irq_handler	EADC02_IRQHandler
+	def_irq_handler	EADC03_IRQHandler
+	def_irq_handler	UART2_IRQHandler
+	def_irq_handler	UART3_IRQHandler
+	def_irq_handler	QSPI1_IRQHandler
+	def_irq_handler	SPI1_IRQHandler
+	def_irq_handler	SPI2_IRQHandler
+	def_irq_handler	USBD_IRQHandler
+	def_irq_handler	OHCI_IRQHandler
+	def_irq_handler	USBOTG_IRQHandler
+	def_irq_handler	CAN0_IRQHandler
+	def_irq_handler	CAN1_IRQHandler
+	def_irq_handler	SC0_IRQHandler
+	def_irq_handler	SC1_IRQHandler
+	def_irq_handler	SC2_IRQHandler
+	def_irq_handler	SPI3_IRQHandler
+	def_irq_handler	SDH0_IRQHandler
+	def_irq_handler	USBD20_IRQHandler
+	def_irq_handler	EMAC_TX_IRQHandler
+	def_irq_handler	EMAC_RX_IRQHandler
+	def_irq_handler	I2S0_IRQHandler
+	def_irq_handler	OPA0_IRQHandler
+	def_irq_handler	CRYPTO_IRQHandler
+	def_irq_handler	GPG_IRQHandler
+	def_irq_handler	EINT6_IRQHandler
+	def_irq_handler	UART4_IRQHandler
+	def_irq_handler	UART5_IRQHandler
+	def_irq_handler	USCI0_IRQHandler
+	def_irq_handler	USCI1_IRQHandler
+	def_irq_handler	BPWM0_IRQHandler
+	def_irq_handler	BPWM1_IRQHandler
+	def_irq_handler	SPIM_IRQHandler
+	def_irq_handler CCAP_IRQHandler
+	def_irq_handler	I2C2_IRQHandler
+	def_irq_handler	QEI0_IRQHandler
+	def_irq_handler	QEI1_IRQHandler
+	def_irq_handler	ECAP0_IRQHandler
+	def_irq_handler	ECAP1_IRQHandler
+	def_irq_handler	GPH_IRQHandler
+	def_irq_handler	EINT7_IRQHandler
+	def_irq_handler	SDH1_IRQHandler
+	def_irq_handler	EHCI_IRQHandler
+	def_irq_handler	USBOTG20_IRQHandler
+	def_irq_handler	TRNG_IRQHandler
+	def_irq_handler	UART6_IRQHandler
+	def_irq_handler	UART7_IRQHandler
+	def_irq_handler	EADC10_IRQHandler
+	def_irq_handler	EADC11_IRQHandler
+	def_irq_handler	EADC12_IRQHandler
+	def_irq_handler	EADC13_IRQHandler
+	def_irq_handler	CAN2_IRQHandler
+
+	.end

--- a/SampleCode/ISP/ISP_HID_20/startup_M480_user_IAR.s
+++ b/SampleCode/ISP/ISP_HID_20/startup_M480_user_IAR.s
@@ -1,0 +1,344 @@
+;/******************************************************************************
+; * @file     startup_M480.s
+; * @version  V1.00
+; * @brief    CMSIS Cortex-M4 Core Device Startup File for M480
+; *
+; * SPDX-License-Identifier: Apache-2.0
+; * @copyright (C) 2017-2020 Nuvoton Technology Corp. All rights reserved.
+;*****************************************************************************/
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  HardFault_Handler
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+        PUBLIC  __vector_table_0x1c
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler
+
+        DCD     NMI_Handler
+        DCD     HardFault_Handler
+        DCD     MemManage_Handler
+        DCD     BusFault_Handler
+        DCD     UsageFault_Handler
+__vector_table_0x1c
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     SVC_Handler
+        DCD     DebugMon_Handler
+        DCD     0
+        DCD     PendSV_Handler
+        DCD     SysTick_Handler
+
+        ; External Interrupts
+
+__Vectors_End
+
+__Vectors       EQU   __vector_table
+__Vectors_Size  EQU   __Vectors_End - __Vectors
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:REORDER:NOROOT(2)
+Reset_Handler
+        ; Unlock Register
+        LDR     R0, =0x40000100
+        LDR     R1, =0x59
+        STR     R1, [R0]
+        LDR     R1, =0x16
+        STR     R1, [R0]
+        LDR     R1, =0x88
+        STR     R1, [R0]
+
+	#ifndef ENABLE_SPIM_CACHE
+        LDR     R0, =0x40000200            ; R0 = Clock Controller Register Base Address
+        LDR     R1, [R0,#0x4]              ; R1 = 0x40000204  (AHBCLK)
+        ORR     R1, R1, #0x4000              
+        STR     R1, [R0,#0x4]              ; CLK->AHBCLK |= CLK_AHBCLK_SPIMCKEN_Msk;
+                
+        LDR     R0, =0x40007000            ; R0 = SPIM Register Base Address
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1,#2                  ; R1 |= SPIM_CTL1_CACHEOFF_Msk
+        STR     R1, [R0,#4]                ; _SPIM_DISABLE_CACHE()
+        LDR     R1, [R0,#4]                ; R1 = SPIM->CTL1
+        ORR     R1, R1, #4                 ; R1 |= SPIM_CTL1_CCMEN_Msk
+        STR     R1, [R0,#4]                ; _SPIM_ENABLE_CCM()
+	#endif
+
+        LDR     R0, =SystemInit
+        BLX     R0
+
+        ; Init POR
+        ; LDR     R2, =0x40000024
+        ; LDR     R1, =0x00005AA5
+        ; STR     R1, [R2]
+
+        ; Lock register
+        LDR     R0, =0x40000100
+        MOVS    R1, #0
+        STR     R1, [R0]
+
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+NMI_Handler
+        B NMI_Handler
+
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+UsageFault_Handler
+        B UsageFault_Handler
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SVC_Handler
+        B SVC_Handler
+
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+DebugMon_Handler
+        B DebugMon_Handler
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+PendSV_Handler
+        B PendSV_Handler
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SysTick_Handler
+        B SysTick_Handler
+
+        PUBWEAK  BOD_IRQHandler
+        PUBWEAK  IRC_IRQHandler
+        PUBWEAK  PWRWU_IRQHandler
+        PUBWEAK  RAMPE_IRQHandler
+        PUBWEAK  CKFAIL_IRQHandler
+        PUBWEAK  RTC_IRQHandler
+        PUBWEAK  TAMPER_IRQHandler
+        PUBWEAK  WDT_IRQHandler
+        PUBWEAK  WWDT_IRQHandler
+        PUBWEAK  EINT0_IRQHandler
+        PUBWEAK  EINT1_IRQHandler
+        PUBWEAK  EINT2_IRQHandler
+        PUBWEAK  EINT3_IRQHandler
+        PUBWEAK  EINT4_IRQHandler
+        PUBWEAK  EINT5_IRQHandler
+        PUBWEAK  GPA_IRQHandler
+        PUBWEAK  GPB_IRQHandler
+        PUBWEAK  GPC_IRQHandler
+        PUBWEAK  GPD_IRQHandler
+        PUBWEAK  GPE_IRQHandler
+        PUBWEAK  GPF_IRQHandler
+        PUBWEAK  QSPI0_IRQHandler
+        PUBWEAK  SPI0_IRQHandler
+        PUBWEAK  BRAKE0_IRQHandler
+        PUBWEAK  PWM0P0_IRQHandler
+        PUBWEAK  PWM0P1_IRQHandler
+        PUBWEAK  PWM0P2_IRQHandler
+        PUBWEAK  BRAKE1_IRQHandler
+        PUBWEAK  PWM1P0_IRQHandler
+        PUBWEAK  PWM1P1_IRQHandler
+        PUBWEAK  PWM1P2_IRQHandler
+        PUBWEAK  TMR0_IRQHandler
+        PUBWEAK  TMR1_IRQHandler
+        PUBWEAK  TMR2_IRQHandler
+        PUBWEAK  TMR3_IRQHandler
+        PUBWEAK  UART0_IRQHandler
+        PUBWEAK  UART1_IRQHandler
+        PUBWEAK  I2C0_IRQHandler
+        PUBWEAK  I2C1_IRQHandler
+        PUBWEAK  PDMA_IRQHandler
+        PUBWEAK  DAC_IRQHandler
+        PUBWEAK  EADC00_IRQHandler
+        PUBWEAK  EADC01_IRQHandler
+        PUBWEAK  ACMP01_IRQHandler
+        PUBWEAK  EADC02_IRQHandler
+        PUBWEAK  EADC03_IRQHandler
+        PUBWEAK  UART2_IRQHandler
+        PUBWEAK  UART3_IRQHandler
+        PUBWEAK  QSPI1_IRQHandler
+        PUBWEAK  SPI1_IRQHandler
+        PUBWEAK  SPI2_IRQHandler
+        PUBWEAK  USBD_IRQHandler
+        PUBWEAK  OHCI_IRQHandler
+        PUBWEAK  USBOTG_IRQHandler
+        PUBWEAK  CAN0_IRQHandler
+        PUBWEAK  CAN1_IRQHandler
+        PUBWEAK  SC0_IRQHandler
+        PUBWEAK  SC1_IRQHandler
+        PUBWEAK  SC2_IRQHandler
+        PUBWEAK  SPI3_IRQHandler
+        PUBWEAK  SDH0_IRQHandler
+        PUBWEAK  USBD20_IRQHandler
+        PUBWEAK  EMAC_TX_IRQHandler
+        PUBWEAK  EMAC_RX_IRQHandler
+        PUBWEAK  I2S0_IRQHandler
+        PUBWEAK  OPA0_IRQHandler
+        PUBWEAK  CRYPTO_IRQHandler
+        PUBWEAK  GPG_IRQHandler
+        PUBWEAK  EINT6_IRQHandler
+        PUBWEAK  UART4_IRQHandler
+        PUBWEAK  UART5_IRQHandler
+        PUBWEAK  USCI0_IRQHandler
+        PUBWEAK  USCI1_IRQHandler
+        PUBWEAK  BPWM0_IRQHandler
+        PUBWEAK  BPWM1_IRQHandler
+        PUBWEAK  SPIM_IRQHandler
+        PUBWEAK  CCAP_IRQHandler
+        PUBWEAK  I2C2_IRQHandler
+        PUBWEAK  QEI0_IRQHandler
+        PUBWEAK  QEI1_IRQHandler
+        PUBWEAK  ECAP0_IRQHandler
+        PUBWEAK  ECAP1_IRQHandler
+        PUBWEAK  GPH_IRQHandler
+        PUBWEAK  EINT7_IRQHandler
+        PUBWEAK  SDH1_IRQHandler
+        PUBWEAK  EHCI_IRQHandler
+        PUBWEAK  USBOTG20_IRQHandler
+        PUBWEAK  TRNG_IRQHandler
+        PUBWEAK  UART6_IRQHandler
+        PUBWEAK  UART7_IRQHandler
+        PUBWEAK  EADC10_IRQHandler
+        PUBWEAK  EADC11_IRQHandler
+        PUBWEAK  EADC12_IRQHandler
+        PUBWEAK  EADC13_IRQHandler
+        PUBWEAK  CAN2_IRQHandler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+
+BOD_IRQHandler
+IRC_IRQHandler
+PWRWU_IRQHandler
+RAMPE_IRQHandler
+CKFAIL_IRQHandler
+RTC_IRQHandler
+TAMPER_IRQHandler
+WDT_IRQHandler
+WWDT_IRQHandler
+EINT0_IRQHandler
+EINT1_IRQHandler
+EINT2_IRQHandler
+EINT3_IRQHandler
+EINT4_IRQHandler
+EINT5_IRQHandler
+GPA_IRQHandler
+GPB_IRQHandler
+GPC_IRQHandler
+GPD_IRQHandler
+GPE_IRQHandler
+GPF_IRQHandler
+QSPI0_IRQHandler
+SPI0_IRQHandler
+BRAKE0_IRQHandler
+PWM0P0_IRQHandler
+PWM0P1_IRQHandler
+PWM0P2_IRQHandler
+BRAKE1_IRQHandler
+PWM1P0_IRQHandler
+PWM1P1_IRQHandler
+PWM1P2_IRQHandler
+TMR0_IRQHandler
+TMR1_IRQHandler
+TMR2_IRQHandler
+TMR3_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+PDMA_IRQHandler
+DAC_IRQHandler
+EADC00_IRQHandler
+EADC01_IRQHandler
+ACMP01_IRQHandler
+EADC02_IRQHandler
+EADC03_IRQHandler
+UART2_IRQHandler
+UART3_IRQHandler
+QSPI1_IRQHandler
+SPI1_IRQHandler
+SPI2_IRQHandler
+USBD_IRQHandler
+OHCI_IRQHandler
+USBOTG_IRQHandler
+CAN0_IRQHandler
+CAN1_IRQHandler
+SC0_IRQHandler
+SC1_IRQHandler
+SC2_IRQHandler
+SPI3_IRQHandler
+SDH0_IRQHandler
+USBD20_IRQHandler
+EMAC_TX_IRQHandler
+EMAC_RX_IRQHandler
+I2S0_IRQHandler
+OPA0_IRQHandler
+CRYPTO_IRQHandler
+GPG_IRQHandler
+EINT6_IRQHandler
+UART4_IRQHandler
+UART5_IRQHandler
+USCI0_IRQHandler
+USCI1_IRQHandler
+BPWM0_IRQHandler
+BPWM1_IRQHandler
+SPIM_IRQHandler
+CCAP_IRQHandler
+I2C2_IRQHandler
+QEI0_IRQHandler
+QEI1_IRQHandler
+ECAP0_IRQHandler
+ECAP1_IRQHandler
+GPH_IRQHandler
+EINT7_IRQHandler
+SDH1_IRQHandler
+EHCI_IRQHandler
+USBOTG20_IRQHandler
+TRNG_IRQHandler
+UART6_IRQHandler
+UART7_IRQHandler
+EADC10_IRQHandler
+EADC11_IRQHandler
+EADC12_IRQHandler
+EADC13_IRQHandler
+CAN2_IRQHandler
+Default_Handler
+        B Default_Handler
+
+
+
+
+        END
+;/*** (C) COPYRIGHT 2016 Nuvoton Technology Corp. ***/

--- a/SampleCode/ISP/ISP_I2C/GCC/Makefile
+++ b/SampleCode/ISP/ISP_I2C/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_I2C/GCC/Makefile
+++ b/SampleCode/ISP/ISP_I2C/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_I2C
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_I2C/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_I2C/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+#STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_I2C/fmc_user.c
+++ b/SampleCode/ISP/ISP_I2C/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_I2C/fmc_user.h
+++ b/SampleCode/ISP/ISP_I2C/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_I2C/isp_user.c
+++ b/SampleCode/ISP/ISP_I2C/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_I2C/isp_user.h
+++ b/SampleCode/ISP/ISP_I2C/isp_user.h
@@ -42,7 +42,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_I2C/main.c
+++ b/SampleCode/ISP/ISP_I2C/main.c
@@ -15,7 +15,12 @@
 uint32_t Pclk0;
 uint32_t Pclk1;
 
-__weak uint32_t CLK_GetPLLClockFreq(void)
+#ifdef __ICCARM__
+#pragma weak CLK_GetPLLClockFreq
+uint32_t CLK_GetPLLClockFreq(void)
+#else
+__attribute__((weak)) uint32_t CLK_GetPLLClockFreq(void)
+#endif
 {
     return FREQ_192MHZ;
 }

--- a/SampleCode/ISP/ISP_RS485/GCC/Makefile
+++ b/SampleCode/ISP/ISP_RS485/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_RS485
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_RS485/GCC/Makefile
+++ b/SampleCode/ISP/ISP_RS485/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_RS485/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_RS485/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+#STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_RS485/fmc_user.c
+++ b/SampleCode/ISP/ISP_RS485/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_RS485/fmc_user.h
+++ b/SampleCode/ISP/ISP_RS485/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_RS485/isp_user.c
+++ b/SampleCode/ISP/ISP_RS485/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_RS485/isp_user.h
+++ b/SampleCode/ISP/ISP_RS485/isp_user.h
@@ -42,7 +42,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_RS485/main.c
+++ b/SampleCode/ISP/ISP_RS485/main.c
@@ -20,7 +20,12 @@
 #define REVEIVE_MODE            (0)
 #define TRANSMIT_MODE           (1)
 
-__weak uint32_t CLK_GetPLLClockFreq(void)
+#ifdef __ICCARM__
+#pragma weak CLK_GetPLLClockFreq
+uint32_t CLK_GetPLLClockFreq(void)
+#else
+__attribute__((weak)) uint32_t CLK_GetPLLClockFreq(void)
+#endif
 {
     return PLL_CLOCK;
 }

--- a/SampleCode/ISP/ISP_RS485/uart_transfer.c
+++ b/SampleCode/ISP/ISP_RS485/uart_transfer.c
@@ -13,7 +13,12 @@
 #include "targetdev.h"
 #include "uart_transfer.h"
 
-__align(4) uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#else
+extern __attribute__((aligned(4))) uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#endif
 
 uint8_t volatile bUartDataReady = 0;
 uint8_t volatile bufhead = 0;
@@ -48,7 +53,12 @@ void UART1_IRQHandler(void)
     }
 }
 
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 void PutString(void)
 {
     uint32_t i;

--- a/SampleCode/ISP/ISP_SPI/GCC/Makefile
+++ b/SampleCode/ISP/ISP_SPI/GCC/Makefile
@@ -1,0 +1,43 @@
+include ./makefile.conf
+NAME=ISP_SPI
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../../../../Library/StdDriver/src/clk.c \
+	../../../../Library/StdDriver/src/timer.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_SPI/GCC/Makefile
+++ b/SampleCode/ISP/ISP_SPI/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_SPI/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_SPI/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+#STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_SPI/fmc_user.c
+++ b/SampleCode/ISP/ISP_SPI/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_SPI/fmc_user.h
+++ b/SampleCode/ISP/ISP_SPI/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_SPI/isp_user.c
+++ b/SampleCode/ISP/ISP_SPI/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_SPI/isp_user.h
+++ b/SampleCode/ISP/ISP_SPI/isp_user.h
@@ -42,7 +42,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_SPI/main.c
+++ b/SampleCode/ISP/ISP_SPI/main.c
@@ -13,12 +13,22 @@
 uint32_t Pclk0;
 uint32_t Pclk1;
 
-__weak uint32_t CLK_GetPLLClockFreq(void)
+#ifdef __ICCARM__
+#pragma weak CLK_GetPLLClockFreq
+uint32_t CLK_GetPLLClockFreq(void)
+#else
+__attribute__((weak)) uint32_t CLK_GetPLLClockFreq(void)
+#endif
 {
     return FREQ_192MHZ;
 }
 
-__weak uint32_t TIMER_Open(TIMER_T *timer, uint32_t u32Mode, uint32_t u32Freq)
+#ifdef __ICCARM__
+#pragma weak TIMER_Open
+uint32_t TIMER_Open(TIMER_T *timer, uint32_t u32Mode, uint32_t u32Freq)
+#else
+__attribute__((weak)) uint32_t TIMER_Open(TIMER_T *timer, uint32_t u32Mode, uint32_t u32Freq)
+#endif
 {
     uint32_t u32Clk = __HXT; // TIMER_GetModuleClock(timer);
     uint32_t u32Cmpr = 0UL, u32Prescale = 0UL;

--- a/SampleCode/ISP/ISP_UART/GCC/Makefile
+++ b/SampleCode/ISP/ISP_UART/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_UART/GCC/Makefile
+++ b/SampleCode/ISP/ISP_UART/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_UART
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_UART/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_UART/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+#STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_UART/fmc_user.c
+++ b/SampleCode/ISP/ISP_UART/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_UART/fmc_user.h
+++ b/SampleCode/ISP/ISP_UART/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_UART/isp_user.c
+++ b/SampleCode/ISP/ISP_UART/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_UART/isp_user.h
+++ b/SampleCode/ISP/ISP_UART/isp_user.h
@@ -42,7 +42,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_UART/uart_transfer.c
+++ b/SampleCode/ISP/ISP_UART/uart_transfer.c
@@ -13,7 +13,12 @@
 #include "targetdev.h"
 #include "uart_transfer.h"
 
-__align(4) uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#else
+extern __attribute__((aligned(4))) uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#endif
 
 uint8_t volatile bUartDataReady = 0;
 uint8_t volatile bufhead = 0;
@@ -48,7 +53,12 @@ void UART0_IRQHandler(void)
     }
 }
 
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 void PutString(void)
 {
     uint32_t i;

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/GCC/Makefile
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/GCC/Makefile
@@ -18,7 +18,7 @@ IPATH= \
 	../../../../Library/CMSIS/Include \
 	../../../../Library/Device/Nuvoton/M480/Include \
 	../../../../Library/StdDriver/inc \
-	User
+	../User
 SRC=$(wildcard \
 	../*.c \
 	../../../../Library/Device/Nuvoton/M480/Source/*.c \

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/GCC/Makefile
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/GCC/Makefile
@@ -1,0 +1,41 @@
+include ./makefile.conf
+NAME=ISP_UART_SPIFLASH_M487KM
+
+STARTUP_DEFS=-D__STARTUP_CLEAR_BSS -D__START=main
+
+# Need following option for LTO as LTO will treat retarget functions as
+# unused without following option
+CFLAGS+=-fno-builtin
+
+LDSCRIPTS=-L. -L$(BASE)Library/Device/Nuvoton/M480/Source/GCC -T gcc_arm.ld
+
+LFLAGS=$(USE_NANO) $(USE_NOHOST) $(LDSCRIPTS) $(GC) $(MAP)
+
+#$(NAME)-$(CORE).axf: main.c $(NAME).c $(STARTUP)
+#	$(CC) $^ $(CFLAGS) $(LFLAGS) -o $@
+IPATH= \
+	../ \
+	../../../../Library/CMSIS/Include \
+	../../../../Library/Device/Nuvoton/M480/Include \
+	../../../../Library/StdDriver/inc \
+	User
+SRC=$(wildcard \
+	../*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/*.c \
+	../../../../Library/Device/Nuvoton/M480/Source/GCC/*.c \
+	../User/*.c \
+)
+OBJS = $(patsubst %.c,./Objects/%.o,$(notdir $(SRC)))
+
+$(NAME): $(OBJS)
+	cd ./Objects && $(CC) *.o $(CFLAGS) $(LFLAGS) $(STARTUP) -o $@.axf $(addprefix -I ../,$(IPATH)) 
+	$(CP) -O binary ./Objects/$@.axf ./Objects/$@.bin
+
+$(OBJS): $(SRC)
+	mkdir -p ./Objects
+	cd ./Objects && $(CC) $(addprefix ../,$^) $(CFLAGS) -c $(addprefix -I ../,$(IPATH))
+
+.PHONY: clean
+
+clean:
+	rm -f ./Objects/*

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/GCC/makefile.conf
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/GCC/makefile.conf
@@ -1,0 +1,36 @@
+# Selecting Core
+CORTEX_M=4
+
+# Use newlib-nano. To disable it, specify USE_NANO=
+USE_NANO=--specs=nano.specs
+
+# Use seimhosting or not
+USE_SEMIHOST=--specs=rdimon.specs
+USE_NOHOST=--specs=nosys.specs
+
+CORE=CM$(CORTEX_M)
+BASE=../../../../../
+
+# Compiler & Linker
+CC=arm-none-eabi-gcc
+CXX=arm-none-eabi-g++
+
+# Binary
+CP=arm-none-eabi-objcopy
+
+# Options for specific architecture
+ARCH_FLAGS=-mthumb -mcpu=cortex-m$(CORTEX_M)
+
+# Startup code
+STARTUP=$(BASE)Library/Device/Nuvoton/M480/Source/GCC/startup_M480.S
+#STARTUP=../../startup_M480_user_GCC.S
+
+# -Os -flto -ffunction-sections -fdata-sections to compile for code size
+CFLAGS=$(ARCH_FLAGS) $(STARTUP_DEFS) -Os -flto -ffunction-sections -fdata-sections
+CXXFLAGS=$(CFLAGS)
+
+# Link for code size
+GC=-Wl,--gc-sections
+
+# Create map file
+MAP=-Wl,-Map=$(NAME).map

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/fmc_user.c
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/fmc_user.c
@@ -9,9 +9,9 @@
 #include "fmc_user.h"
 
 
-int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end, unsigned int *data)
+int FMC_Proc(uint32_t u32Cmd, uint32_t addr_start, uint32_t addr_end, uint32_t *data)
 {
-    unsigned int u32Addr, Reg;
+    uint32_t u32Addr, Reg;
 
     for (u32Addr = addr_start; u32Addr < addr_end; data++)
     {
@@ -68,7 +68,7 @@ int FMC_Proc(unsigned int u32Cmd, unsigned int addr_start, unsigned int addr_end
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data)
 {
     return FMC_Proc(FMC_ISPCMD_PROGRAM, u32Addr, u32Addr + 4, &u32Data);
 }
@@ -87,7 +87,7 @@ int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data)
  *              before using this function. User can check the status of
  *              Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data)
 {
     return FMC_Proc(FMC_ISPCMD_READ, u32Addr, u32Addr + 4, data);
 }
@@ -105,18 +105,18 @@ int FMC_Read_User(unsigned int u32Addr, unsigned int *data)
  *             before using this function. User can check the status of
  *             Register Write-Protection Function with DrvSYS_IsProtectedRegLocked().
  */
-int FMC_Erase_User(unsigned int u32Addr)
+int FMC_Erase_User(uint32_t u32Addr)
 {
     return FMC_Proc(FMC_ISPCMD_PAGE_ERASE, u32Addr, u32Addr + 4, 0);
 }
 
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)    // Read data from flash
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)    // Read data from flash
 {
     FMC_Proc(FMC_ISPCMD_READ, addr_start, addr_end, data);
     return;
 }
 
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data)  // Write data into flash
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data)  // Write data into flash
 {
     FMC_Proc(FMC_ISPCMD_PROGRAM, addr_start, addr_end, data);
     return;
@@ -124,9 +124,9 @@ void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *dat
 
 #define FMC_BLOCK_SIZE           (FMC_FLASH_PAGE_SIZE * 4UL)
 
-int EraseAP(unsigned int addr_start, unsigned int size)
+int EraseAP(uint32_t addr_start, uint32_t size)
 {
-    unsigned int u32Addr, u32Cmd, u32Size;
+    uint32_t u32Addr, u32Cmd, u32Size;
     u32Addr = addr_start;
 
     while (size > 0)
@@ -167,9 +167,9 @@ int EraseAP(unsigned int addr_start, unsigned int size)
     return 0;
 }
 
-void UpdateConfig(unsigned int *data, unsigned int *res)
+void UpdateConfig(uint32_t *data, uint32_t *res)
 {
-    unsigned int u32Size = 16;
+    uint32_t u32Size = 16;
     FMC_ENABLE_CFG_UPDATE();
     FMC_Proc(FMC_ISPCMD_PAGE_ERASE, Config0, Config0 + 8, 0);
     FMC_Proc(FMC_ISPCMD_PROGRAM, Config0, Config0 + u32Size, data);

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/fmc_user.h
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/fmc_user.h
@@ -29,13 +29,13 @@
 #define _FMC_DISABLE_CFG_UPDATE()  (FMC->ISPCTL &= ~FMC_ISPCTL_CFGUEN_Msk) /*!< Disable CONFIG Update Function */
 
 
-int FMC_Write_User(unsigned int u32Addr, unsigned int u32Data);
-int FMC_Read_User(unsigned int u32Addr, unsigned int *data);
-int FMC_Erase_User(unsigned int u32Addr);
-void ReadData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-void WriteData(unsigned int addr_start, unsigned int addr_end, unsigned int *data);
-int EraseAP(unsigned int addr_start, unsigned int size);
-void UpdateConfig(unsigned int *data, unsigned int *res);
+int FMC_Write_User(uint32_t u32Addr, uint32_t u32Data);
+int FMC_Read_User(uint32_t u32Addr, uint32_t *data);
+int FMC_Erase_User(uint32_t u32Addr);
+void ReadData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+void WriteData(uint32_t addr_start, uint32_t addr_end, uint32_t *data);
+int EraseAP(uint32_t addr_start, uint32_t size);
+void UpdateConfig(uint32_t *data, uint32_t *res);
 
 void GetDataFlashInfo(uint32_t *addr, uint32_t *size);
 

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/isp_user.c
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/isp_user.c
@@ -11,8 +11,15 @@
 #include "string.h"
 #include "isp_user.h"
 
-__align(4) uint8_t response_buff[64];
-__align(4) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+uint8_t response_buff[64];
+#pragma data_alignment=4
+static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#else
+__attribute__((aligned(4))) uint8_t response_buff[64];
+__attribute__((aligned(4))) static uint8_t aprom_buf[FMC_FLASH_PAGE_SIZE];
+#endif
 uint32_t bUpdateApromCmd;
 uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/isp_user.h
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/isp_user.h
@@ -45,7 +45,16 @@ extern uint32_t GetApromSize(void);
 extern int ParseCmd(unsigned char *buffer, uint8_t len);
 extern uint32_t g_apromSize, g_dataFlashAddr, g_dataFlashSize;
 
-extern __align(4) uint8_t usb_rcvbuf[];
-extern __align(4) uint8_t usb_sendbuf[];
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t usb_rcvbuf[];
+#pragma data_alignment=4
+extern uint8_t usb_sendbuf[];
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t usb_rcvbuf[];
+extern __attribute__((aligned(4))) uint8_t usb_sendbuf[];
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 #endif  // #ifndef ISP_USER_H

--- a/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/uart_transfer.c
+++ b/SampleCode/ISP/ISP_UART_SPIFLASH_M487KM/uart_transfer.c
@@ -13,7 +13,12 @@
 #include "targetdev.h"
 #include "uart_transfer.h"
 
-__align(4) uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#else
+extern __attribute__((aligned(4))) uint8_t  uart_rcvbuf[MAX_PKT_SIZE] = {0};
+#endif
 
 uint8_t volatile bUartDataReady = 0;
 uint8_t volatile bufhead = 0;
@@ -48,7 +53,12 @@ void UART0_IRQHandler(void)
     }
 }
 
-extern __align(4) uint8_t response_buff[64];
+#ifdef __ICCARM__
+#pragma data_alignment=4
+extern uint8_t response_buff[64];
+#else
+extern __attribute__((aligned(4))) uint8_t response_buff[64];
+#endif
 void PutString(void)
 {
     uint32_t i;


### PR DESCRIPTION
1. Modify __align(4) into __attribute __((aligned(4))), #pragma data_alignment=4 for __ICCARM __
2. Modify unsigned int into uint32_t in fmc_user prevent from warning.
3. Remove unuse interrupt vector in the startup file if necessary.

All of the code doesn't tested, need to be confirm through the target board. 
May add NuEclipse project metadata will be ideal.