### PR TITLE
Refined CAN Settings Logic in the Code

### DIFF
--- a/Library/StdDriver/src/can.c
+++ b/Library/StdDriver/src/can.c
@@ -574,17 +574,18 @@ int32_t CAN_SetRxMsgObjAndMsk(CAN_T *tCAN, uint8_t u8MsgObj, uint8_t u8idType, u
 
         if(u8idType == CAN_STD_ID)    /* According STD/EXT ID format,Configure Mask and Arbitration register */
         {
+            tCAN->IF[u32MsgIfNum].MASK1 = 0ul;
+            tCAN->IF[u32MsgIfNum].MASK2 = (u32idmask & 0x7FFul) << 2;
             tCAN->IF[u32MsgIfNum].ARB1 = 0ul;
             tCAN->IF[u32MsgIfNum].ARB2 = CAN_IF_ARB2_MSGVAL_Msk | (u32id & 0x7FFul) << 2;
         }
         else
         {
+            tCAN->IF[u32MsgIfNum].MASK1 = u32idmask & 0xFFFFul;
+            tCAN->IF[u32MsgIfNum].MASK2 = CAN_IF_MASK2_MXTD_Msk | (u32idmask & 0x1FFF0000ul) >> 16;
             tCAN->IF[u32MsgIfNum].ARB1 = u32id & 0xFFFFul;
             tCAN->IF[u32MsgIfNum].ARB2 = CAN_IF_ARB2_MSGVAL_Msk | CAN_IF_ARB2_XTD_Msk | (u32id & 0x1FFF0000ul) >> 16;
         }
-
-        tCAN->IF[u32MsgIfNum].MASK1 = (u32idmask & 0xFFFFul);
-        tCAN->IF[u32MsgIfNum].MASK2 = (u32idmask >> 16) & 0xFFFFul;
 
         /* tCAN->IF[u32MsgIfNum].MCON |= CAN_IF_MCON_UMASK_Msk | CAN_IF_MCON_RXIE_Msk; */
         tCAN->IF[u32MsgIfNum].MCON = CAN_IF_MCON_UMASK_Msk | CAN_IF_MCON_RXIE_Msk;
@@ -653,8 +654,8 @@ int32_t CAN_SetRxMsgObj(CAN_T *tCAN, uint8_t u8MsgObj, uint8_t u8idType, uint32_
             tCAN->IF[u32MsgIfNum].ARB2 = CAN_IF_ARB2_MSGVAL_Msk | CAN_IF_ARB2_XTD_Msk | (u32id & 0x1FFF0000ul) >> 16;
         }
 
-        /* tCAN->IF[u8MsgIfNum].MCON |= CAN_IF_MCON_UMASK_Msk | CAN_IF_MCON_RXIE_Msk; */
-        tCAN->IF[u32MsgIfNum].MCON = CAN_IF_MCON_UMASK_Msk | CAN_IF_MCON_RXIE_Msk;
+        /* tCAN->IF[u8MsgIfNum].MCON |= CAN_IF_MCON_RXIE_Msk; */
+        tCAN->IF[u32MsgIfNum].MCON = CAN_IF_MCON_RXIE_Msk;
         if(u8singleOrFifoLast)
         {
             tCAN->IF[u32MsgIfNum].MCON |= CAN_IF_MCON_EOB_Msk;


### PR DESCRIPTION
This pull request improves the logic related to CAN configuration, specifically correcting the misuse of mask settings and simplifying the setup for message objects. The changes include:

**Modification 1:** The `CAN_SetRxMsgObj` function no longer incorrectly sets the `UMASK` bit in the `CAN_IFn_MCON` register, aligning with the chip manual's guidance.

**Modification 2:** The `CAN_SetRxMsgObjAndMsk` function has been updated for clarity, making the setup for standard and extended frame IDs more intuitive.

**Before and After:**

- **Standard ID Setup:**
  - Before: `CAN_SetRxMsgObjAndMsk(tCAN, MSG(0), CAN_STD_ID, 0x003, (0x00F << 2) << 16, TRUE);`
  - After: `CAN_SetRxMsgObjAndMsk(tCAN, MSG(0), CAN_STD_ID, 0x003, 0x00F, TRUE);`

- **Extended ID Setup:**
  - Before: `CAN_SetRxMsgObjAndMsk(tCAN, MSG(0), CAN_EXT_ID, 0x00000003, CAN_IF_MASK2_MXTD_Msk | 0x0000000F, TRUE);`
  - After: `CAN_SetRxMsgObjAndMsk(tCAN, MSG(0), CAN_EXT_ID. 0x00000003, 0x0000000F, TRUE);`

These updates ensure the CAN configuration is both correct and user-friendly, adhering closely to the intended design and documentation.
